### PR TITLE
Fix syntax error when checking whether comment is supported

### DIFF
--- a/nftables.go
+++ b/nftables.go
@@ -104,15 +104,15 @@ func newInternal(family Family, table string, execer execer) (Interface, error) 
 
 	// Check that (a) nft works, (b) we have permission, (c) the kernel is new enough
 	// to support object comments.
-	cmd = exec.Command(nft.path, "--check", "add", "table", string(nft.family), nft.table,
-		"{", "comment", `"test"`, "}",
-	)
-	_, err = nft.exec.Run(cmd)
-	if err != nil {
+	tx := nft.NewTransaction()
+	tx.Add(&Table{
+		Comment: PtrTo("test"),
+	})
+	if err := nft.Check(context.TODO(), tx); err != nil {
 		// Try again, checking just that (a) nft works, (b) we have permission.
-		cmd := exec.Command(nft.path, "--check", "add", "table", string(nft.family), nft.table)
-		_, err = nft.exec.Run(cmd)
-		if err != nil {
+		tx := nft.NewTransaction()
+		tx.Add(&Table{})
+		if err := nft.Check(context.TODO(), tx); err != nil {
 			return nil, fmt.Errorf("could not run nftables command: %w", err)
 		}
 

--- a/nftables_test.go
+++ b/nftables_test.go
@@ -39,9 +39,8 @@ func newTestInterface(t *testing.T, family Family, tableName string) (Interface,
 			stdout: "nftables v1.0.7 (Old Doc Yak)\n",
 		},
 		expectedCmd{
-			args: []string{"/nft", "--check", "add", "table", ip, tableName,
-				"{", "comment", `"test"`, "}",
-			},
+			args:  []string{"/nft", "--check", "-f", "-"},
+			stdin: fmt.Sprintf("add table %s %s { comment \"test\" ; }\n", ip, tableName),
 		},
 	)
 	nft, err := newInternal(family, tableName, fexec)
@@ -445,11 +444,8 @@ func TestFeatures(t *testing.T) {
 					stdout: "nftables v1.0.7 (Old Doc Yak)\n",
 				},
 				{
-					args: []string{
-						"/nft", "--check",
-						"add", "table", "ip", "testing",
-						"{", "comment", `"test"`, "}",
-					},
+					args:  []string{"/nft", "--check", "-f", "-"},
+					stdin: "add table ip testing { comment \"test\" ; }\n",
 				},
 			},
 			result: &nftContext{
@@ -467,18 +463,13 @@ func TestFeatures(t *testing.T) {
 					stdout: "nftables v1.0.7 (Old Doc Yak)\n",
 				},
 				{
-					args: []string{
-						"/nft", "--check",
-						"add", "table", "ip", "testing",
-						"{", "comment", `"test"`, "}",
-					},
-					err: fmt.Errorf("Error: syntax error, unexpected comment"),
+					args:  []string{"/nft", "--check", "-f", "-"},
+					stdin: "add table ip testing { comment \"test\" ; }\n",
+					err:   fmt.Errorf("Error: syntax error, unexpected comment"),
 				},
 				{
-					args: []string{
-						"/nft", "--check",
-						"add", "table", "ip", "testing",
-					},
+					args:  []string{"/nft", "--check", "-f", "-"},
+					stdin: "add table ip testing\n",
 				},
 			},
 			result: &nftContext{


### PR DESCRIPTION
The check failed with "Error: syntax error, unexpected '}', expecting newline or semicolon" even when comment is supported.