### PR TITLE
Fix ParseDump with an "empty" table declaration

### DIFF
--- a/fake.go
+++ b/fake.go
@@ -550,7 +550,7 @@ func (fake *Fake) ParseDump(data string) (err error) {
 		}
 	}()
 	tx := fake.NewTransaction()
-	commonRegexp := regexp.MustCompile(fmt.Sprintf(`add %s %s %s (.*)`, noSpaceGroup, fake.family, fake.table))
+	commonRegexp := regexp.MustCompile(fmt.Sprintf(`add ([^ ]*) %s %s( (.*))?`, fake.family, fake.table))
 
 	for i, line = range lines {
 		line = strings.TrimSpace(line)
@@ -578,7 +578,7 @@ func (fake *Fake) ParseDump(data string) (err error) {
 		default:
 			return fmt.Errorf("unknown object %s", match[1])
 		}
-		err = obj.parse(match[2])
+		err = obj.parse(match[3])
 		if err != nil {
 			return err
 		}

--- a/fake_test.go
+++ b/fake_test.go
@@ -593,7 +593,7 @@ func TestFakeParseDump(t *testing.T) {
 		{
 			ipFamily: IPv4Family,
 			dump: `
-			add table ip kube-proxy { comment "" ; }
+			add table ip kube-proxy
 			add chain ip kube-proxy anotherchain
 			add chain ip kube-proxy chain { comment "foo" ; }
 			add map ip kube-proxy map1 { type ipv4_addr . inet_proto . inet_service ; }


### PR DESCRIPTION
You can have an `add table` with no `{}` clause, but `ParseDump` didn't handle that.

(I also removed the use of `noSpaceGroup` here just to make the regexp more self-documenting.)