### PR TITLE
add support for nftables counter objects

### DIFF
--- a/objects_test.go
+++ b/objects_test.go
@@ -104,6 +104,12 @@ func TestObjects(t *testing.T) {
 			err:    "not implemented",
 		},
 		{
+			name:   "invalid reset table",
+			verb:   resetVerb,
+			object: &Table{},
+			err:    "not implemented",
+		},
+		{
 			name:   "invalid add table with Handle",
 			verb:   addVerb,
 			object: &Table{Handle: PtrTo(5)},
@@ -158,6 +164,14 @@ func TestObjects(t *testing.T) {
 		{
 			name: "flush flowtable",
 			verb: flushVerb,
+			object: &Flowtable{
+				Name: "myflowtable",
+			},
+			err: "not implemented",
+		},
+		{
+			name: "invalid reset flowtable",
+			verb: resetVerb,
 			object: &Flowtable{
 				Name: "myflowtable",
 			},
@@ -287,6 +301,12 @@ func TestObjects(t *testing.T) {
 		{
 			name:   "invalid insert chain",
 			verb:   insertVerb,
+			object: &Chain{Name: "mychain"},
+			err:    "not implemented",
+		},
+		{
+			name:   "invalid reset chain",
+			verb:   resetVerb,
 			object: &Chain{Name: "mychain"},
 			err:    "not implemented",
 		},
@@ -425,6 +445,12 @@ func TestObjects(t *testing.T) {
 			err:    "not implemented",
 		},
 		{
+			name:   "invalid reset rule",
+			verb:   resetVerb,
+			object: &Rule{Chain: "mychain", Rule: "drop"},
+			err:    "not implemented",
+		},
+		{
 			name:   "invalid add rule with no Chain",
 			verb:   addVerb,
 			object: &Rule{Rule: "drop"},
@@ -523,6 +549,12 @@ func TestObjects(t *testing.T) {
 		{
 			name:   "invalid insert set",
 			verb:   insertVerb,
+			object: &Set{Name: "myset", Type: "ipv4_addr"},
+			err:    "not implemented",
+		},
+		{
+			name:   "invalid reset set",
+			verb:   resetVerb,
 			object: &Set{Name: "myset", Type: "ipv4_addr"},
 			err:    "not implemented",
 		},
@@ -634,6 +666,12 @@ func TestObjects(t *testing.T) {
 			err:    "not implemented",
 		},
 		{
+			name:   "invalid reset map",
+			verb:   resetVerb,
+			object: &Map{Name: "mymap", Type: "ipv4_addr : ipv4_addr"},
+			err:    "not implemented",
+		},
+		{
 			name:   "invalid add map without Name",
 			verb:   addVerb,
 			object: &Map{Type: "ipv4_addr : ipv4_addr"},
@@ -738,6 +776,12 @@ func TestObjects(t *testing.T) {
 			err:    "not implemented",
 		},
 		{
+			name:   "invalid reset element",
+			verb:   resetVerb,
+			object: &Element{Set: "myset", Key: []string{"10.0.0.1"}},
+			err:    "not implemented",
+		},
+		{
 			name:   "invalid insert element",
 			verb:   insertVerb,
 			object: &Element{Set: "myset", Key: []string{"10.0.0.1"}},
@@ -748,6 +792,103 @@ func TestObjects(t *testing.T) {
 			verb:   replaceVerb,
 			object: &Element{Set: "myset", Key: []string{"10.0.0.1"}},
 			err:    "not implemented",
+		},
+		// Counters
+		{
+			name:   "add counter with comment",
+			verb:   addVerb,
+			object: &Counter{Name: "test-counter", Comment: PtrTo("counter for unit tests")},
+			out:    "add counter ip mytable test-counter { comment \"counter for unit tests\" ; }",
+		},
+		{
+			name:   "add counter without comment",
+			verb:   addVerb,
+			object: &Counter{Name: "test-counter"},
+			out:    "add counter ip mytable test-counter",
+		},
+		{
+			name:   "add counter with comment, packets and bytes.",
+			verb:   addVerb,
+			object: &Counter{Name: "test-counter", Comment: PtrTo("counter for unit tests"), Packets: PtrTo[uint64](100), Bytes: PtrTo[uint64](500)},
+			out:    "add counter ip mytable test-counter { packets 100 bytes 500 ; comment \"counter for unit tests\" ; }",
+		},
+		{
+			name:   "invalid add counter without name",
+			verb:   addVerb,
+			object: &Counter{},
+			err:    "no counter name specified",
+		},
+		{
+			name:   "invalid add counter with handle",
+			verb:   addVerb,
+			object: &Counter{Name: "dummy-counter", Handle: PtrTo(100)},
+			err:    "cannot specify Handle in add operation",
+		},
+		{
+			name:   "create counter with comment",
+			verb:   createVerb,
+			object: &Counter{Name: "test-counter", Comment: PtrTo("counter for unit tests")},
+			out:    "create counter ip mytable test-counter { comment \"counter for unit tests\" ; }",
+		},
+		{
+			name:   "invalid crete counter with packets without bytes",
+			verb:   createVerb,
+			object: &Counter{Name: "test-counter", Packets: PtrTo[uint64](100)},
+			err:    "cannot specify Packets without Bytes in create operation",
+		},
+		{
+			name:   "invalid crete counter with bytes without packets",
+			verb:   createVerb,
+			object: &Counter{Name: "test-counter", Bytes: PtrTo[uint64](1500)},
+			err:    "cannot specify Bytes without Packets in create operation",
+		},
+		{
+			name:   "create counter without name",
+			verb:   createVerb,
+			object: &Counter{},
+			err:    "no counter name specified",
+		},
+		{
+			name:   "delete counter by name",
+			verb:   deleteVerb,
+			object: &Counter{Name: "test-counter"},
+			out:    "delete counter ip mytable test-counter",
+		},
+		{
+			name:   "delete counter by handle",
+			verb:   deleteVerb,
+			object: &Counter{Name: "test-counter", Handle: PtrTo(5)},
+			out:    "delete counter ip mytable handle 5",
+		},
+		{
+			name:   "invalid insert counter",
+			verb:   insertVerb,
+			object: &Counter{Name: "test-counter"},
+			err:    "insert is not implemented for counters",
+		},
+		{
+			name:   "invalid replace counter",
+			verb:   replaceVerb,
+			object: &Counter{Name: "test-counter"},
+			err:    "replace is not implemented for counters",
+		},
+		{
+			name:   "invalid flush counter",
+			verb:   flushVerb,
+			object: &Counter{Name: "test-counter"},
+			err:    "flush is not implemented for counters",
+		},
+		{
+			name:   "invalid reset counter",
+			verb:   resetVerb,
+			object: &Counter{Name: "test-counter"},
+			out:    "reset counter ip mytable test-counter",
+		},
+		{
+			name:   "invalid reset without name",
+			verb:   resetVerb,
+			object: &Counter{},
+			err:    "no counter name specified",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -780,8 +921,8 @@ func TestObjects(t *testing.T) {
 		})
 	}
 
-	// add, create, flush, insert, replace, delete
-	numVerbs := 6
+	// add, create, flush, insert, replace, delete, reset
+	numVerbs := 7
 	for objType, verbs := range tested {
 		if len(verbs) != numVerbs {
 			t.Errorf("expected to test %d verbs for %s, got %d (%v)", numVerbs, objType, len(verbs), verbs)

--- a/transaction.go
+++ b/transaction.go
@@ -45,6 +45,7 @@ const (
 	replaceVerb verb = "replace"
 	deleteVerb  verb = "delete"
 	flushVerb   verb = "flush"
+	resetVerb   verb = "reset"
 )
 
 // populateCommandBuf populates the transaction as series of nft commands to the given bytes.Buffer.
@@ -138,4 +139,11 @@ func (tx *Transaction) Flush(obj Object) {
 // transaction is Run.
 func (tx *Transaction) Delete(obj Object) {
 	tx.operation(deleteVerb, obj)
+}
+
+// Reset adds a "nft reset" operation to tx, resetting obj (which must be a Counter).
+// The Reset() call always succeeds, but if obj does not exist then an error will be
+// returned when the transaction is Run.
+func (tx *Transaction) Reset(obj Object) {
+	tx.operation(resetVerb, obj)
 }

--- a/types.go
+++ b/types.go
@@ -438,3 +438,24 @@ type Flowtable struct {
 	// deleting it. When adding a new object, this must be nil
 	Handle *int
 }
+
+// Counter represents named counter
+type Counter struct {
+	// Name is the name of the named counter
+	Name string
+
+	// Comment is an optional comment for the counter
+	Comment *string
+
+	// Packets represents numbers of packets tracked by the counter.
+	// This will be filled in by ListCounters() but can be nil when creating new counter.
+	Packets *uint64
+
+	// Bytes represents numbers of bytes tracked by the counter.
+	// This will be filled in by ListCounters() but can be nil when creating new counter.
+	Bytes *uint64
+
+	// Handle is an identifier that can be used to uniquely identify an object when
+	// deleting it. When adding a new object, this must be nil
+	Handle *int
+}


### PR DESCRIPTION
This PR adds support for native named nftables counters.
https://wiki.nftables.org/wiki-nftables/index.php/Counters

Fixes: https://github.com/kubernetes-sigs/knftables/issues/20


Sample Usage:
https://github.com/kubernetes/kubernetes/pull/129505

Output (kind):

```
root@kind-worker:/# nft list counters
table ip kube-proxy {
	counter traffic-to-invalid-ports {
		comment "tarck packets sent to invalid ports of cluster ips"
		packets 0 bytes 0
	}
}
table ip6 kube-proxy {
	counter traffic-to-invalid-ports {
		comment "tarck packets sent to invalid ports of cluster ips"
		packets 0 bytes 0
	}
}


root@kind-worker:/# for i in {1..100}; do curl --silent 10.96.0.10:12345; done;


root@kind-worker:/# nft list counters
table ip kube-proxy {
	counter traffic-to-invalid-ports {
		comment "tarck packets sent to invalid ports of cluster ips"
		packets 100 bytes 6000
	}
}
table ip6 kube-proxy {
	counter traffic-to-invalid-ports {
		comment "tarck packets sent to invalid ports of cluster ips"
		packets 0 bytes 0
	}
}
```


