### PR TITLE
Add support for multiple family/table combinations within a single transaction

### DIFF
--- a/objects.go
+++ b/objects.go
@@ -69,12 +69,12 @@ func (table *Table) validate(verb verb) error {
 func (table *Table) writeOperation(verb verb, ctx *nftContext, writer io.Writer) {
 	// Special case for delete-by-handle
 	if verb == deleteVerb && table.Handle != nil {
-		fmt.Fprintf(writer, "delete table %s handle %d", ctx.family, *table.Handle)
+		fmt.Fprintf(writer, "delete table %s handle %d", table.Family, *table.Handle)
 		return
 	}
 
 	// All other cases refer to the table by name
-	fmt.Fprintf(writer, "%s table %s %s", verb, ctx.family, ctx.table)
+	fmt.Fprintf(writer, "%s table %s %s", verb, table.Family, table.Name)
 	if verb == addVerb || verb == createVerb {
 		hasComment := table.Comment != nil && !ctx.noObjectComments
 		if hasComment || len(table.Flags) != 0 {
@@ -161,11 +161,11 @@ func (chain *Chain) validate(verb verb) error {
 func (chain *Chain) writeOperation(verb verb, ctx *nftContext, writer io.Writer) {
 	// Special case for delete-by-handle
 	if verb == deleteVerb && chain.Handle != nil {
-		fmt.Fprintf(writer, "delete chain %s %s handle %d", ctx.family, ctx.table, *chain.Handle)
+		fmt.Fprintf(writer, "delete chain %s %s handle %d", chain.Family, chain.Table, *chain.Handle)
 		return
 	}
 
-	fmt.Fprintf(writer, "%s chain %s %s %s", verb, ctx.family, ctx.table, chain.Name)
+	fmt.Fprintf(writer, "%s chain %s %s %s", verb, chain.Family, chain.Table, chain.Name)
 	if verb == addVerb || verb == createVerb {
 		if chain.Type != nil || (chain.Comment != nil && !ctx.noObjectComments) {
 			fmt.Fprintf(writer, " {")
@@ -180,7 +180,7 @@ func (chain *Chain) writeOperation(verb verb, ctx *nftContext, writer io.Writer)
 				// versions of nft don't accept certain named priorities
 				// in all contexts (eg, "dstnat" priority in the "output"
 				// hook).
-				if priority, err := ParsePriority(ctx.family, string(*chain.Priority)); err == nil {
+				if priority, err := ParsePriority(chain.Family, string(*chain.Priority)); err == nil {
 					fmt.Fprintf(writer, " priority %d ;", priority)
 				} else {
 					fmt.Fprintf(writer, " priority %s ;", *chain.Priority)
@@ -264,7 +264,7 @@ func (rule *Rule) validate(verb verb) error {
 }
 
 func (rule *Rule) writeOperation(verb verb, ctx *nftContext, writer io.Writer) {
-	fmt.Fprintf(writer, "%s rule %s %s %s", verb, ctx.family, ctx.table, rule.Chain)
+	fmt.Fprintf(writer, "%s rule %s %s %s", verb, rule.Family, rule.Table, rule.Chain)
 	if rule.Index != nil {
 		fmt.Fprintf(writer, " index %d", *rule.Index)
 	} else if rule.Handle != nil {
@@ -334,11 +334,11 @@ func (set *Set) validate(verb verb) error {
 func (set *Set) writeOperation(verb verb, ctx *nftContext, writer io.Writer) {
 	// Special case for delete-by-handle
 	if verb == deleteVerb && set.Handle != nil {
-		fmt.Fprintf(writer, "delete set %s %s handle %d", ctx.family, ctx.table, *set.Handle)
+		fmt.Fprintf(writer, "delete set %s %s handle %d", set.Family, set.Table, *set.Handle)
 		return
 	}
 
-	fmt.Fprintf(writer, "%s set %s %s %s", verb, ctx.family, ctx.table, set.Name)
+	fmt.Fprintf(writer, "%s set %s %s %s", verb, set.Family, set.Table, set.Name)
 	if verb == addVerb || verb == createVerb {
 		fmt.Fprintf(writer, " {")
 
@@ -424,11 +424,11 @@ func (mapObj *Map) validate(verb verb) error {
 func (mapObj *Map) writeOperation(verb verb, ctx *nftContext, writer io.Writer) {
 	// Special case for delete-by-handle
 	if verb == deleteVerb && mapObj.Handle != nil {
-		fmt.Fprintf(writer, "delete map %s %s handle %d", ctx.family, ctx.table, *mapObj.Handle)
+		fmt.Fprintf(writer, "delete map %s %s handle %d", mapObj.Family, mapObj.Table, *mapObj.Handle)
 		return
 	}
 
-	fmt.Fprintf(writer, "%s map %s %s %s", verb, ctx.family, ctx.table, mapObj.Name)
+	fmt.Fprintf(writer, "%s map %s %s %s", verb, mapObj.Family, mapObj.Table, mapObj.Name)
 	if verb == addVerb || verb == createVerb {
 		fmt.Fprintf(writer, " {")
 
@@ -568,7 +568,7 @@ func (element *Element) writeOperation(verb verb, ctx *nftContext, writer io.Wri
 		name = element.Map
 	}
 
-	fmt.Fprintf(writer, "%s element %s %s %s { %s", verb, ctx.family, ctx.table, name,
+	fmt.Fprintf(writer, "%s element %s %s %s { %s", verb, element.Family, element.Table, name,
 		strings.Join(element.Key, " . "))
 
 	if verb == addVerb || verb == createVerb {
@@ -639,11 +639,11 @@ func (flowtable *Flowtable) validate(verb verb) error {
 func (flowtable *Flowtable) writeOperation(verb verb, ctx *nftContext, writer io.Writer) {
 	// Special case for delete-by-handle
 	if verb == deleteVerb && flowtable.Handle != nil {
-		fmt.Fprintf(writer, "delete flowtable %s %s handle %d", ctx.family, ctx.table, *flowtable.Handle)
+		fmt.Fprintf(writer, "delete flowtable %s %s handle %d", flowtable.Family, flowtable.Table, *flowtable.Handle)
 		return
 	}
 
-	fmt.Fprintf(writer, "%s flowtable %s %s %s", verb, ctx.family, ctx.table, flowtable.Name)
+	fmt.Fprintf(writer, "%s flowtable %s %s %s", verb, flowtable.Family, flowtable.Table, flowtable.Name)
 	if verb == addVerb || verb == createVerb {
 		fmt.Fprintf(writer, " {")
 
@@ -749,11 +749,11 @@ func (counter *Counter) validate(verb verb) error {
 func (counter *Counter) writeOperation(verb verb, ctx *nftContext, writer io.Writer) {
 	// Special case for delete-by-handle
 	if verb == deleteVerb && counter.Handle != nil {
-		fmt.Fprintf(writer, "delete counter %s %s handle %d", ctx.family, ctx.table, *counter.Handle)
+		fmt.Fprintf(writer, "delete counter %s %s handle %d", counter.Family, counter.Table, *counter.Handle)
 		return
 	}
 
-	fmt.Fprintf(writer, "%s counter %s %s ", verb, ctx.family, ctx.table)
+	fmt.Fprintf(writer, "%s counter %s %s ", verb, counter.Family, counter.Table)
 	switch verb {
 	case addVerb, createVerb:
 		fmt.Fprint(writer, counter.Name)

--- a/objects_test.go
+++ b/objects_test.go
@@ -911,7 +911,8 @@ func TestObjects(t *testing.T) {
 
 			if err == nil && tc.err == "" {
 				b := &strings.Builder{}
-				ctx := &nftContext{family: IPv4Family, table: "mytable"}
+				ctx := &nftContext{defaultFamily: IPv4Family, defaultTable: "mytable"}
+				adjustTableFamily(ctx, tc.object)
 				tc.object.writeOperation(tc.verb, ctx, b)
 				out := strings.TrimSuffix(b.String(), "\n")
 				if out != tc.out {
@@ -979,7 +980,8 @@ func TestNoObjectComments(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			b := &strings.Builder{}
-			ctx := &nftContext{family: IPv4Family, table: "mytable", noObjectComments: true}
+			ctx := &nftContext{defaultFamily: IPv4Family, defaultTable: "mytable", noObjectComments: true}
+			adjustTableFamily(ctx, tc.object)
 			tc.object.writeOperation(addVerb, ctx, b)
 			out := strings.TrimSuffix(b.String(), "\n")
 			if out != tc.out {

--- a/transaction.go
+++ b/transaction.go
@@ -84,6 +84,9 @@ func (tx *Transaction) operation(verb verb, obj Object) {
 	if tx.err != nil {
 		return
 	}
+	if tx.err = adjustTableFamily(tx.nftContext, obj); tx.err != nil {
+		return
+	}
 	if tx.err = obj.validate(verb); tx.err != nil {
 		return
 	}

--- a/types.go
+++ b/types.go
@@ -35,8 +35,8 @@ type Object interface {
 	// validate validates an object for an operation
 	validate(verb verb) error
 
-	// writeOperation writes out an "nft" operation involving the object. It assumes
-	// that the object has been validated.
+	// Writes an "nft" operation for the object. The object is assumed to be validated,
+	// with its table and family inherited from the nftContext if applicable.
 	writeOperation(verb verb, ctx *nftContext, writer io.Writer)
 
 	// parse is the opposite of writeOperation; it fills Object fields based on an "nft add"
@@ -82,6 +82,12 @@ const (
 
 // Table represents an nftables table.
 type Table struct {
+	// Name of the table. if not specified the default table of the context is used instead
+	Name string
+
+	// Family defines the protocol family for this table. If not specified the default family of the context is used instead
+	Family Family
+
 	// Comment is an optional comment for the table. (Requires kernel >= 5.10 and
 	// nft >= 0.9.7; otherwise this field will be silently ignored. Requires
 	// nft >= 1.0.8 to include comments in List() results.)
@@ -216,6 +222,12 @@ type Chain struct {
 	// Name is the name of the chain.
 	Name string
 
+	// Table specifies the name of the table this chain belongs to. if not specified the default table of the context is used instead
+	Table string
+
+	// Family defines the protocol family for this chain. If not specified the default family of the context is used instead
+	Family Family
+
 	// Type is the chain type; this must be set for a base chain and unset for a
 	// regular chain.
 	Type *BaseChainType
@@ -249,6 +261,12 @@ type Chain struct {
 type Rule struct {
 	// Chain is the name of the chain that contains this rule
 	Chain string
+
+	// Table specifies the name of the table this rule belongs to. if not specified the default table of the context is used instead
+	Table string
+
+	// Family defines the protocol family for this rule. If not specified the default family of the context is used instead
+	Family Family
 
 	// Rule is the rule in standard nftables syntax. (Should be empty on Delete, but
 	// is ignored if not.) Note that this does not include any rule comment, which is
@@ -309,6 +327,12 @@ type Set struct {
 	// Name is the name of the set.
 	Name string
 
+	// Table specifies the name of the table this set belongs to. if not specified the default table of the context is used instead
+	Table string
+
+	// Family defines the protocol family for this set. If not specified the default family of the context is used instead
+	Family Family
+
 	// Type is the type of the set key (eg "ipv4_addr"). Either Type or TypeOf, but
 	// not both, must be non-empty.
 	Type string
@@ -354,6 +378,12 @@ type Map struct {
 	// Name is the name of the map.
 	Name string
 
+	// Table specifies the name of the table this map belongs to. if not specified the default table of the context is used instead
+	Table string
+
+	// Family defines the protocol family for this map. If not specified the default family of the context is used instead
+	Family Family
+
 	// Type is the type of the map key and value (eg "ipv4_addr : verdict"). Either
 	// Type or TypeOf, but not both, must be non-empty.
 	Type string
@@ -392,6 +422,12 @@ type Map struct {
 
 // Element represents a set or map element
 type Element struct {
+	// Table specifies the name of the table this element belongs to. if not specified the default table of the context is used instead
+	Table string
+
+	// Family defines the protocol family for this element. If not specified the default family of the context is used instead
+	Family Family
+
 	// Set is the name of the set that contains this element (or the empty string if
 	// this is a map element.)
 	Set string
@@ -426,6 +462,12 @@ type Flowtable struct {
 	// Name is the name of the flowtable.
 	Name string
 
+	// Table specifies the name of the table this flowtable belongs to. if not specified the default table of the context is used instead
+	Table string
+
+	// Family defines the protocol family for this flowtable. If not specified the default family of the context is used instead
+	Family Family
+
 	// The Priority can be a signed integer or FlowtableIngressPriority which stands for 0.
 	// Addition and subtraction can be used to set relative priority, e.g. filter + 5 equals to 5.
 	Priority *FlowtableIngressPriority
@@ -443,6 +485,12 @@ type Flowtable struct {
 type Counter struct {
 	// Name is the name of the named counter
 	Name string
+
+	// Table specifies the name of the table this counter belongs to. if not specified the default table of the context is used instead
+	Table string
+
+	// Family defines the protocol family for this counter. If not specified the default family of the context is used instead
+	Family Family
 
 	// Comment is an optional comment for the counter
 	Comment *string

--- a/util.go
+++ b/util.go
@@ -115,3 +115,90 @@ func Concat(args ...interface{}) string {
 	}
 	return b.String()
 }
+
+// adjustTableFamily updates the provided Object to inherit the table and family from the nftContext
+// if they are not already explicitly set on the object.
+func adjustTableFamily(nft *nftContext, obj Object) error {
+	table, family, err := extractTableAndFamily(obj)
+	if err != nil {
+		return err
+	}
+
+	if table == "" || family == "" {
+		if table == "" {
+			table = nft.defaultTable
+		}
+		if family == "" {
+			family = nft.defaultFamily
+		}
+		err = setTableAndFamily(obj, table, family)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func extractTableAndFamily(obj Object) (string, Family, error) {
+	if obj == nil {
+		return "", "", nil
+	}
+
+	switch v := obj.(type) {
+	case *Table:
+		// For a Table object, we need to extract the `Name` field
+		return v.Name, v.Family, nil
+	case *Chain:
+		return v.Table, v.Family, nil
+	case *Rule:
+		return v.Table, v.Family, nil
+	case *Set:
+		return v.Table, v.Family, nil
+	case *Map:
+		return v.Table, v.Family, nil
+	case *Element:
+		return v.Table, v.Family, nil
+	case *Flowtable:
+		return v.Table, v.Family, nil
+	case *Counter:
+		return v.Table, v.Family, nil
+	default:
+		return "", "", fmt.Errorf("type of object not supported")
+	}
+}
+
+func setTableAndFamily(obj Object, table string, family Family) error {
+	if obj == nil {
+		return nil
+	}
+
+	switch v := obj.(type) {
+	case *Table:
+		v.Name = table
+		v.Family = family
+	case *Chain:
+		v.Table = table
+		v.Family = family
+	case *Rule:
+		v.Table = table
+		v.Family = family
+	case *Set:
+		v.Table = table
+		v.Family = family
+	case *Map:
+		v.Table = table
+		v.Family = family
+	case *Element:
+		v.Table = table
+		v.Family = family
+	case *Flowtable:
+		v.Table = table
+		v.Family = family
+	case *Counter:
+		v.Table = table
+		v.Family = family
+	default:
+		return fmt.Errorf("type of object not supported")
+	}
+	return nil
+}


### PR DESCRIPTION
This PR introduces support for performing operations within a single transaction across different combinations of tables and families.

Previously, the library restricted operations to the table and family defined at interface creation. As a result, if users needed to mutate objects across multiple families or tables, they were forced to create multiple interfaces and execute separate transactions from each interface.

This creates a window of time where the system can be in an intermediate state, with some tables updated and others not.
This is problematic, especially for Istio, since it has a configuration involving multiple tables that needs to be updated at runtime (due to configuration change and/or upgrade of Istio itself).
In Istio, during a configuration change or an upgrade, we must guarantee that all tables are updated together to avoid traffic disruption or any other unintended behavior.

Notable changes from the PR:
- The constructor knftables.New() has been updated and no longer takes family and table as arguments. Instead, the interface now exposes SetDefaultFamily() and SetDefaultTable() methods to define defaults (n.b: users are not forced to ahve defaults). These defaults are applied whenever an object or method doesn’t explicitly set its own table or family.
- Each object has a `table` and `family` field you can set when adding an operation to your transaction.
e.g: 
```
tx.Add(&knftables.Table{name: "my-table2"})
tx.Add(&Rule{
        Chain: "chain2",
        Table: "my-table2"
        Rule:  "ip daddr 10.0.0.0/8 drop",
})
```
These fields are optional. If omitted, the transaction will use the default family and default table set in the nftContext.
- the ListX methods have been updated to accept family and table as part of their signature. If these are passed as empty strings, the nftContext's defaults are used.
For example, List now has the signature `List(ctx context.Context, family Family, table string, objectType string) ([]string, error)` which provides fine-grained control over the list cmd.
- Fake no longer has fake.Table but it has a fake.State which is a map that handles multiple table-family combinations all-in-one place.
The map uses FamilyTablePair as key.
`fake.State[FamilyTablePair{IPv4Family, "my-table"}].Chains|Sets|etc`
- In the past, the creation of a realNFTables or fakeNFTables instance involved calling Check(), where a transaction would create the user-provided table with a specific comment to verify permissions and support for comments. Now, the code no longer uses the user-provided table (since it is no longer present), but instead uses a hardcoded "knftables-test" table in the inet family.

Technically the APIs breakage for old users can be mitigated (with some tradeoffs on clarity or complexity):
- New() could still take table and family as input in the signature instead of relying exclusively on a setter for defaultFamily and defaultTable.
- ListX methods could have a variadic to set table and family to not break existing users of ListX.
- Fake could still deliver a fake.Table on top of the new Fake.State, fake.Table will expose the defaultTable/Family entry in the State map. Probably, an API breakage on Fake is not the highest priority to mitigate.