### PR TITLE
Support interfaces/transactions with multiple families/tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,11 @@ if err != nil {
 ```
 
 (If you want to operate on multiple tables or multiple nftables
-families, you will need separate `Interface` objects for each. If you
-need to check whether the system supports an nftables feature as with
-`nft --check`, use `nft.Check()`, which works the same as `nft.Run()`
-below.)
+families, you have two options: you can either create separate
+`Interface` objects for each table, or you can create a single
+`Interface` and pass `""` for the family and table. In that case, you
+will need to explicitly fill in the `Family` and `Table` fields of
+every `Chain`, `Rule`, etc, object you create.)
 
 You can use the `List`, `ListRules`, and `ListElements` methods on the
 `Interface` to check if objects exist. `List` returns the names of
@@ -115,6 +116,9 @@ use the `knftables.IsNotFound()` and `knftables.IsAlreadyExists()`
 methods to check for those well-known error types. In a large
 transaction, there is no supported way to determine exactly which
 operation failed.
+
+(You can also pass a transaction to `nft.Check()`, which uses `nft
+--check`, but otherwise behaves the same as `nft.Run()`.)
 
 ## `knftables.Transaction` operations
 

--- a/fake_test.go
+++ b/fake_test.go
@@ -886,3 +886,160 @@ func TestFakeParseDump(t *testing.T) {
 		})
 	}
 }
+
+func TestFakeMultiTable(t *testing.T) {
+	fake := NewFake("", "")
+
+	tx := fake.NewTransaction()
+
+	tx.Add(&Table{
+		Family: IPv4Family,
+		Name:   "kube-proxy",
+	})
+	tx.Add(&Chain{
+		Family:  IPv4Family,
+		Table:   "kube-proxy",
+		Name:    "chain",
+		Comment: PtrTo("foo"),
+	})
+	tx.Add(&Rule{
+		Family: IPv4Family,
+		Table:  "kube-proxy",
+		Chain:  "chain",
+		Rule:   "ip daddr 10.0.0.0/8 drop",
+	})
+	tx.Add(&Rule{
+		Family:  IPv4Family,
+		Table:   "kube-proxy",
+		Chain:   "chain",
+		Rule:    "masquerade",
+		Comment: PtrTo("comment"),
+	})
+
+	tx.Add(&Table{
+		Family: IPv6Family,
+		Name:   "anothertable",
+	})
+	tx.Add(&Chain{
+		Family: IPv6Family,
+		Table:  "anothertable",
+		Name:   "anotherchain",
+	})
+	tx.Add(&Rule{
+		Family:  IPv6Family,
+		Table:   "anothertable",
+		Chain:   "anotherchain",
+		Rule:    "ip saddr 1.2.3.4 drop",
+		Comment: PtrTo("drop rule"),
+	})
+	tx.Add(&Rule{
+		Family:  IPv6Family,
+		Table:   "anothertable",
+		Chain:   "anotherchain",
+		Rule:    "ip daddr 5.6.7.8 reject",
+		Comment: PtrTo("reject rule"),
+	})
+
+	// The transaction should contain exactly those commands, in order
+	expected := strings.TrimPrefix(dedent.Dedent(`
+		add table ip kube-proxy
+		add chain ip kube-proxy chain { comment "foo" ; }
+		add rule ip kube-proxy chain ip daddr 10.0.0.0/8 drop
+		add rule ip kube-proxy chain masquerade comment "comment"
+		add table ip6 anothertable
+		add chain ip6 anothertable anotherchain
+		add rule ip6 anothertable anotherchain ip saddr 1.2.3.4 drop comment "drop rule"
+		add rule ip6 anothertable anotherchain ip daddr 5.6.7.8 reject comment "reject rule"
+		`), "\n")
+	diff := cmp.Diff(expected, tx.String())
+	if diff != "" {
+		t.Errorf("unexpected transaction content:\n%s", diff)
+	}
+
+	err := fake.Run(context.Background(), tx)
+	if err != nil {
+		t.Fatalf("unexpected error from Run: %v", err)
+	}
+
+	if fake.Table != nil {
+		t.Fatalf("fake.Table is set")
+	}
+
+	v4Table := fake.Tables[IPv4Family]["kube-proxy"]
+	if v4Table == nil {
+		t.Fatalf("fake.Tables[ip][kube-proxy] is nil")
+	}
+	v6Table := fake.Tables[IPv6Family]["anothertable"]
+	if v6Table == nil {
+		t.Fatalf("fake.Tables[ip6][anothertable] is nil")
+	}
+
+	chain := v4Table.Chains["chain"]
+	if chain == nil || len(v4Table.Chains) != 1 {
+		t.Fatalf("unexpected contents of table.Chains: %+v", v4Table.Chains)
+	}
+
+	if len(chain.Rules) != 2 {
+		t.Fatalf("unexpected chain.Rules length: expected 2, got %d", len(chain.Rules))
+	}
+	expectedRule := "ip daddr 10.0.0.0/8 drop"
+	if chain.Rules[0].Rule != expectedRule {
+		t.Fatalf("unexpected chain.Rules content: expected %q, got %q", expectedRule, chain.Rules[0].Rule)
+	}
+	expectedRule = "masquerade"
+	if chain.Rules[1].Rule != expectedRule {
+		t.Fatalf("unexpected chain.Rules content: expected %q, got %q", expectedRule, chain.Rules[1].Rule)
+	}
+	expectedComment := "comment"
+	if chain.Rules[1].Comment == nil {
+		t.Fatalf("unexpected chain.Rules content: expected comment %q, got nil", expectedComment)
+	} else if *chain.Rules[1].Comment != expectedComment {
+		t.Fatalf("unexpected chain.Rules content: expected comment %q, got %q", expectedComment, *chain.Rules[1].Comment)
+	}
+
+	chain = v6Table.Chains["anotherchain"]
+	if chain == nil || len(v6Table.Chains) != 1 {
+		t.Fatalf("unexpected contents of v6Table.Chains: %+v", v6Table.Chains)
+	}
+
+	if len(chain.Rules) != 2 {
+		t.Fatalf("unexpected chain.Rules length: expected 2, got %d", len(chain.Rules))
+	}
+	expectedRule = "ip saddr 1.2.3.4 drop"
+	if chain.Rules[0].Rule != expectedRule {
+		t.Fatalf("unexpected chain.Rules content: expected %q, got %q", expectedRule, chain.Rules[0].Rule)
+	}
+	// Save this Rule object for later
+	ruleToDelete := chain.Rules[0]
+
+	// Dump() includes both tables
+	expected = strings.TrimPrefix(dedent.Dedent(`
+		add table ip kube-proxy
+		add chain ip kube-proxy chain { comment "foo" ; }
+		add rule ip kube-proxy chain ip daddr 10.0.0.0/8 drop
+		add rule ip kube-proxy chain masquerade comment "comment"
+		add table ip6 anothertable
+		add chain ip6 anothertable anotherchain
+		add rule ip6 anothertable anotherchain ip saddr 1.2.3.4 drop comment "drop rule"
+		add rule ip6 anothertable anotherchain ip daddr 5.6.7.8 reject comment "reject rule"
+		`), "\n")
+	diff = cmp.Diff(expected, fake.Dump())
+	if diff != "" {
+		t.Errorf("unexpected Dump content:\n%s", diff)
+	}
+
+	// Delete a rule from the non-default table, and ensure it was actually deleted.
+	tx = fake.NewTransaction()
+	tx.Delete(ruleToDelete)
+	err = fake.Run(context.Background(), tx)
+	if err != nil {
+		t.Fatalf("unexpected error from Run: %v", err)
+	}
+
+	tx = fake.NewTransaction()
+	tx.Delete(ruleToDelete)
+	err = fake.Run(context.Background(), tx)
+	if err == nil || !IsNotFound(err) {
+		t.Fatalf("unexpected error from Run: %v", err)
+	}
+}

--- a/objects_test.go
+++ b/objects_test.go
@@ -892,7 +892,8 @@ func TestObjects(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			err := tc.object.validate(tc.verb)
+			ctx := &nftContext{family: IPv4Family, table: "mytable"}
+			err := tc.object.validate(tc.verb, ctx)
 			if err == nil {
 				if tc.err != "" {
 					t.Errorf("expected error with %q but got none", tc.err)
@@ -911,7 +912,6 @@ func TestObjects(t *testing.T) {
 
 			if err == nil && tc.err == "" {
 				b := &strings.Builder{}
-				ctx := &nftContext{family: IPv4Family, table: "mytable"}
 				tc.object.writeOperation(tc.verb, ctx, b)
 				out := strings.TrimSuffix(b.String(), "\n")
 				if out != tc.out {

--- a/transaction.go
+++ b/transaction.go
@@ -84,7 +84,7 @@ func (tx *Transaction) operation(verb verb, obj Object) {
 	if tx.err != nil {
 		return
 	}
-	if tx.err = obj.validate(verb); tx.err != nil {
+	if tx.err = obj.validate(verb, tx.nftContext); tx.err != nil {
 		return
 	}
 

--- a/types.go
+++ b/types.go
@@ -43,7 +43,7 @@ type Object interface {
 	// command. line is the part of the line after "nft add <type> <family> <tablename>"
 	// (so for most types it starts with the object name).
 	// If error is returned, Object's fields may be partially filled, therefore Object should not be used.
-	parse(line string) error
+	parse(family Family, table, line string) error
 }
 
 // Family is an nftables family

--- a/types.go
+++ b/types.go
@@ -33,7 +33,7 @@ const (
 // implement this interface.
 type Object interface {
 	// validate validates an object for an operation
-	validate(verb verb) error
+	validate(verb verb, ctx *nftContext) error
 
 	// writeOperation writes out an "nft" operation involving the object. It assumes
 	// that the object has been validated.
@@ -82,6 +82,14 @@ const (
 
 // Table represents an nftables table.
 type Table struct {
+	// Family is the nftables family of the table. You do not normally need to fill
+	// this in because it will be filled in for you automatically from the Interface.
+	Family Family
+
+	// Name is the name of the table. You do not normally need to fill this in
+	// because it will be filled in for you automatically from the Interface.
+	Name string
+
 	// Comment is an optional comment for the table. (Requires kernel >= 5.10 and
 	// nft >= 0.9.7; otherwise this field will be silently ignored. Requires
 	// nft >= 1.0.8 to include comments in List() results.)
@@ -213,6 +221,15 @@ const (
 // Chain represents an nftables chain; either a "base chain" (if Type, Hook, and Priority
 // are specified), or a "regular chain" (if they are not).
 type Chain struct {
+	// Family is the nftables family of the chain's table. You do not normally need to
+	// fill this in because it will be filled in for you automatically from the
+	// Interface.
+	Family Family
+
+	// Table is the name of the chain's table. You do not normally need to fill this
+	// in because it will be filled in for you automatically from the Interface.
+	Table string
+
 	// Name is the name of the chain.
 	Name string
 
@@ -247,6 +264,15 @@ type Chain struct {
 
 // Rule represents a rule in a chain
 type Rule struct {
+	// Family is the nftables family of the rule's table. You do not normally need to
+	// fill this in because it will be filled in for you automatically from the
+	// Interface.
+	Family Family
+
+	// Table is the name of the rule's table. You do not normally need to fill this
+	// in because it will be filled in for you automatically from the Interface.
+	Table string
+
 	// Chain is the name of the chain that contains this rule
 	Chain string
 
@@ -306,6 +332,15 @@ const (
 
 // Set represents the definition of an nftables set (but not its elements)
 type Set struct {
+	// Family is the nftables family of the set's table. You do not normally need to
+	// fill this in because it will be filled in for you automatically from the
+	// Interface.
+	Family Family
+
+	// Table is the name of the set's table. You do not normally need to fill this
+	// in because it will be filled in for you automatically from the Interface.
+	Table string
+
 	// Name is the name of the set.
 	Name string
 
@@ -351,6 +386,15 @@ type Set struct {
 
 // Map represents the definition of an nftables map (but not its elements)
 type Map struct {
+	// Family is the nftables family of the map's table. You do not normally need to
+	// fill this in because it will be filled in for you automatically from the
+	// Interface.
+	Family Family
+
+	// Table is the name of the map's table. You do not normally need to fill this
+	// in because it will be filled in for you automatically from the Interface.
+	Table string
+
 	// Name is the name of the map.
 	Name string
 
@@ -392,6 +436,15 @@ type Map struct {
 
 // Element represents a set or map element
 type Element struct {
+	// Family is the nftables family of the element's table. You do not normally need
+	// to fill this in because it will be filled in for you automatically from the
+	// Interface.
+	Family Family
+
+	// Table is the name of the element's table. You do not normally need to fill this
+	// in because it will be filled in for you automatically from the Interface.
+	Table string
+
 	// Set is the name of the set that contains this element (or the empty string if
 	// this is a map element.)
 	Set string
@@ -423,6 +476,15 @@ const (
 // Flowtable represents an nftables flowtable.
 // https://wiki.nftables.org/wiki-nftables/index.php/Flowtables
 type Flowtable struct {
+	// Family is the nftables family of the flowtable's table. You do not normally
+	// need to fill this in because it will be filled in for you automatically from
+	// the Interface.
+	Family Family
+
+	// Table is the name of the flowtable's table. You do not normally need to fill
+	// this in because it will be filled in for you automatically from the Interface.
+	Table string
+
 	// Name is the name of the flowtable.
 	Name string
 
@@ -441,6 +503,15 @@ type Flowtable struct {
 
 // Counter represents named counter
 type Counter struct {
+	// Family is the nftables family of the counter's table. You do not normally
+	// need to fill this in because it will be filled in for you automatically from
+	// the Interface.
+	Family Family
+
+	// Table is the name of the counter's table. You do not normally need to fill
+	// this in because it will be filled in for you automatically from the Interface.
+	Table string
+
 	// Name is the name of the named counter
 	Name string
 


### PR DESCRIPTION
Inspired by #24, but fully backward-compatible (at the expense of being perhaps slightly ugly)...

This adds `Family` and `Name` fields to `Table`; and `Family` and `Table` fields to every other object type. Assuming you are using the API in the traditional way (with an explicit family and table name passed to `knftables.New()`/`knftables.NewFake()`), then you can leave the new fields empty, and they won't be filled in by `ParseDump` or the `List` APIs (because doing so might break existing unit tests). If you _do_ set them, you _must_ set them to the family and table name associated with the Interface.

However, additionally, you can now create an Interface with `knftables.New("", "")` or `knftables.NewFake("", "")`, and in that case, there is no default, and you must explicitly specify the table and family of each object you add to a transaction. And `ParseDump` does fill in the family/table when parsing, though the `List` APIs no longer work at all, since they don't have any way to specify the table... (You'd have to create a second Interface specific to a single table if you need to use a `List` API.)

So yeah, obviously this is not how I would have designed the API if I'd wanted this functionality from the beginning, but I'd really like to avoid breaking API since we're starting to get into situations where there are modules that use knftables that import other modules that use knftables (with `github.com/containernetworking/plugins` being a commonly-imported one), so API breaks will be increasingly painful. (We may eventually want a `/v2`...)