### PR TITLE
add `nft destroy` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,13 +129,73 @@ operation failed.
 `knftables.Transaction` operations correspond to the top-level commands
 in the `nft` binary. Currently-supported operations are:
 
-- `tx.Add()`: adds an object, which may already exist, as with `nft add`
+- `tx.Add()`: creates an object if it does not already exist, as with `nft add`
 - `tx.Create()`: creates an object, which must not already exist, as with `nft create`
 - `tx.Flush()`: flushes the contents of a table/chain/set/map, as with `nft flush`
 - `tx.Reset()`: resets a counter, as with `nft reset`
-- `tx.Delete()`: deletes an object, as with `nft delete`
-- `tx.Insert()`: inserts a rule before another rule, as with `nft insert rule`
+- `tx.Delete()`: deletes an object, which must exist, as with `nft delete`
+- `tx.Destroy()`: deletes an object if it exists, as with `nft destroy`
+
+For `Rule` objects the semantics and operations are slightly different:
+
+- `tx.Add()`: appends a rule to a chain or adds it after an existing rule, as with `nft add rule`
+- `tx.Insert()`: prepends a rule to a chain or inserts it before another rule, as with `nft insert rule`
 - `tx.Replace()`: replaces a rule, as with `nft replace rule`
+- `tx.Delete()`/`tx.Destroy()`: deletes the rule with the given `Handle`, as with `nft delete rule`/`nft destroy rule`
+
+### `Destroy` operations
+
+Actually doing `nft destroy` requires a fairly new kernel (6.3 or
+later) and `nft` binary (1.0.8 or later). Trying to run a transaction
+containing a `Destroy` operation on an older host will result in an
+error.
+
+There are two construct-time options to help out with this. First, you
+can specify `RequireDestroy`, if you want knftables construction to
+fail on older hosts:
+
+```golang
+nft, err := knftables.New(knftables.IPv4Family, "my-table", knftables.RequireDestroy)
+if err != nil {
+        ...
+```
+
+Alternatively, you can construct the `Interface` with the
+`EmulateDestroy` option:
+
+```golang
+nft, err := knftables.New(knftables.IPv4Family, "my-table", knftables.EmulateDestroy)
+```
+
+in which case knftables will attempt to emulate `nft destroy` if it is
+not available by doing a combination of an `add` and a `delete` (where
+the `add` will succeed whether the object previously existed or not,
+and then the `delete` will succeed because the object definitely
+exists at that point). To ensure that this emulation will work, if
+`EmulateDestroy` is in effect then `tx.Destroy()` will require that
+you pass it an object that is suitable for passing to both `tx.Add()`
+and `tx.Delete()` (even if the system you are currently on supports
+`nft destroy`). In particular, this means that when `EmulateDestroy`
+is in effect:
+
+  - You can only `Destroy()` objects by `Name` or `Key`, not by
+    `Handle`.
+
+  - You can't `Destroy()` a `Rule` (since `Rule`s can only be deleted
+    by `Handle`).
+
+  - If you include optional fields in the object (e.g. base chain
+    properties), they need to be correct (since an `Add()` would fail
+    if you passed different values). However, note that you *can* just
+    leave the optional fields unset.
+
+  - When `Destroy()`ing a `Set` or `Map` you must include the correct
+    `Type` (since an `Add()` would fail if you did not specify it or
+    specified it incorrectly).
+
+  - When `Destroy()`ing a `Map` `Element` you must include the correct
+    `Value` (since an `Add()` would fail if you did not specify it or
+    specified it incorrectly).
 
 ## Objects
 
@@ -179,11 +239,6 @@ aren't just blindly copying over old iptables APIs"), because chains
 tend to have static rules and dynamic sets/maps, rather than having
 dynamic rules. If you aren't sure if a chain has the correct rules,
 you can just `Flush` it and recreate all of the rules.
-
-The "destroy" (delete-without-ENOENT) command that exists in newer
-versions of `nft` is not currently supported because it would be
-unexpectedly heavyweight to emulate on systems that don't have it, so
-it is better (for now) to force callers to implement it by hand.
 
 `ListRules` returns `Rule` objects without the `Rule` field filled in,
 because it uses the JSON API to list the rules, but there is no easy

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ in the `nft` binary. Currently-supported operations are:
 - `tx.Add()`: adds an object, which may already exist, as with `nft add`
 - `tx.Create()`: creates an object, which must not already exist, as with `nft create`
 - `tx.Flush()`: flushes the contents of a table/chain/set/map, as with `nft flush`
+- `tx.Reset()`: resets a counter, as with `nft reset`
 - `tx.Delete()`: deletes an object, as with `nft delete`
 - `tx.Insert()`: inserts a rule before another rule, as with `nft insert rule`
 - `tx.Replace()`: replaces a rule, as with `nft replace rule`
@@ -144,6 +145,7 @@ The currently-supported objects are:
 - `Set`
 - `Map`
 - `Element`
+- `Counter`
 
 Optional fields in objects can be filled in with the help of the
 `PtrTo()` function, which just returns a pointer to its argument.
@@ -164,8 +166,7 @@ the current state of the fake nftables database.
 
 ## Missing APIs
 
-Various top-level object types are not yet supported (notably the
-"stateful objects" like `counter`).
+Various top-level object types are not yet supported.
 
 Most IPTables libraries have an API for "add this rule only if it
 doesn't already exist", but that does not seem as useful in nftables

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ if err != nil {
 }
 ```
 
+`knftables.New` also takes a comma-separated list of options after the
+family and table name; see the documentation for that function for
+more information.
+
 (If you want to operate on multiple tables or multiple nftables
 families, you have two options: you can either create separate
 `Interface` objects for each table, or you can create a single

--- a/fake_test.go
+++ b/fake_test.go
@@ -275,8 +275,13 @@ func TestFakeRun(t *testing.T) {
 		t.Errorf("unexpected contents of map1: %+v", m)
 	}
 
-	// Check delete element from map works
+	// Check delete element from map works, test Destroy on a non-existent element.
 	tx = fake.NewTransaction()
+	tx.Destroy(&Element{
+		Map:   "map1",
+		Key:   []string{"1.2.3.4", "sctp", "999"},
+		Value: []string{"drop"},
+	})
 	tx.Delete(&Element{
 		Map: "map1",
 		Key: []string{"192.168.0.1", "tcp", "80"},

--- a/nftables.go
+++ b/nftables.go
@@ -204,14 +204,11 @@ func (nft *realNFTables) Run(ctx context.Context, tx *Transaction) error {
 	}
 
 	nft.buffer.Reset()
-	err := tx.populateCommandBuf(nft.buffer)
-	if err != nil {
-		return err
-	}
+	tx.populateCommandBuf(nft.buffer)
 
 	cmd := exec.CommandContext(ctx, nft.path, "-f", "-")
 	cmd.Stdin = nft.buffer
-	_, err = nft.exec.Run(cmd)
+	_, err := nft.exec.Run(cmd)
 	return err
 }
 
@@ -225,14 +222,11 @@ func (nft *realNFTables) Check(ctx context.Context, tx *Transaction) error {
 	}
 
 	nft.buffer.Reset()
-	err := tx.populateCommandBuf(nft.buffer)
-	if err != nil {
-		return err
-	}
+	tx.populateCommandBuf(nft.buffer)
 
 	cmd := exec.CommandContext(ctx, nft.path, "--check", "-f", "-")
 	cmd.Stdin = nft.buffer
-	_, err = nft.exec.Run(cmd)
+	_, err := nft.exec.Run(cmd)
 	return err
 }
 

--- a/nftables_test.go
+++ b/nftables_test.go
@@ -509,6 +509,10 @@ func TestFeatures(t *testing.T) {
 					args:  []string{"/nft", "--check", "-f", "-"},
 					stdin: "add table ip testing { comment \"test\" ; }\n",
 				},
+				{
+					args:  []string{"/nft", "--check", "-f", "-"},
+					stdin: "destroy table ip testing\n",
+				},
 			},
 			result: &nftContext{
 				family: IPv4Family,
@@ -532,6 +536,10 @@ func TestFeatures(t *testing.T) {
 				{
 					args:  []string{"/nft", "--check", "-f", "-"},
 					stdin: "add table ip testing\n",
+				},
+				{
+					args:  []string{"/nft", "--check", "-f", "-"},
+					stdin: "destroy table ip testing\n",
 				},
 			},
 			result: &nftContext{
@@ -558,6 +566,109 @@ func TestFeatures(t *testing.T) {
 				},
 			},
 			result: nil,
+		},
+		{
+			name:    "EmulateDestroy when destroy is unavailable",
+			options: []Option{EmulateDestroy},
+			commands: []expectedCmd{
+				{
+					args: []string{
+						"/nft", "--version",
+					},
+					stdout: "nftables v1.0.7 (Old Doc Yak)\n",
+				},
+				{
+					args:  []string{"/nft", "--check", "-f", "-"},
+					stdin: "add table ip testing { comment \"test\" ; }\n",
+				},
+				{
+					args:  []string{"/nft", "--check", "-f", "-"},
+					stdin: "destroy table ip testing\n",
+					err:   fmt.Errorf("Error: syntax error, blah blah"),
+				},
+			},
+			result: &nftContext{
+				family: IPv4Family,
+				table:  "testing",
+
+				emulateDestroy: true,
+				hasDestroy:     false,
+			},
+		},
+		{
+			name:    "EmulateDestroy when destroy is available",
+			options: []Option{EmulateDestroy},
+			commands: []expectedCmd{
+				{
+					args: []string{
+						"/nft", "--version",
+					},
+					stdout: "nftables v1.0.7 (Old Doc Yak)\n",
+				},
+				{
+					args:  []string{"/nft", "--check", "-f", "-"},
+					stdin: "add table ip testing { comment \"test\" ; }\n",
+				},
+				{
+					args:  []string{"/nft", "--check", "-f", "-"},
+					stdin: "destroy table ip testing\n",
+				},
+			},
+			result: &nftContext{
+				family: IPv4Family,
+				table:  "testing",
+
+				emulateDestroy: true,
+				hasDestroy:     true,
+			},
+		},
+		{
+			name:    "RequireDestroy when destroy is not available",
+			options: []Option{RequireDestroy},
+			commands: []expectedCmd{
+				{
+					args: []string{
+						"/nft", "--version",
+					},
+					stdout: "nftables v1.0.7 (Old Doc Yak)\n",
+				},
+				{
+					args:  []string{"/nft", "--check", "-f", "-"},
+					stdin: "add table ip testing { comment \"test\" ; }\n",
+				},
+				{
+					args:  []string{"/nft", "--check", "-f", "-"},
+					stdin: "destroy table ip testing\n",
+					err:   fmt.Errorf("Error: syntax error, blah blah"),
+				},
+			},
+			result: nil,
+		},
+		{
+			name:    "RequireDestroy when destroy is available",
+			options: []Option{RequireDestroy},
+			commands: []expectedCmd{
+				{
+					args: []string{
+						"/nft", "--version",
+					},
+					stdout: "nftables v1.0.7 (Old Doc Yak)\n",
+				},
+				{
+					args:  []string{"/nft", "--check", "-f", "-"},
+					stdin: "add table ip testing { comment \"test\" ; }\n",
+				},
+				{
+					args:  []string{"/nft", "--check", "-f", "-"},
+					stdin: "destroy table ip testing\n",
+				},
+			},
+			result: &nftContext{
+				family: IPv4Family,
+				table:  "testing",
+
+				hasDestroy: true,
+			},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/nftables_test.go
+++ b/nftables_test.go
@@ -480,6 +480,7 @@ func TestListElements(t *testing.T) {
 func TestFeatures(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
+		options  []Option
 		commands []expectedCmd
 		result   *nftContext
 	}{
@@ -540,11 +541,29 @@ func TestFeatures(t *testing.T) {
 				noObjectComments: true,
 			},
 		},
+		{
+			name:    "NoObjectCommentEmulation",
+			options: []Option{NoObjectCommentEmulation},
+			commands: []expectedCmd{
+				{
+					args: []string{
+						"/nft", "--version",
+					},
+					stdout: "nftables v1.0.7 (Old Doc Yak)\n",
+				},
+				{
+					args:  []string{"/nft", "--check", "-f", "-"},
+					stdin: "add table ip testing { comment \"test\" ; }\n",
+					err:   fmt.Errorf("Error: syntax error, unexpected comment"),
+				},
+			},
+			result: nil,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			fexec := newFakeExec(t)
 			fexec.expected = tc.commands
-			nft, err := newInternal(IPv4Family, "testing", fexec)
+			nft, err := newInternal(IPv4Family, "testing", fexec, tc.options...)
 			if err != nil {
 				if tc.result != nil {
 					t.Fatalf("Unexpected error creating Interface: %v", err)

--- a/objects_test.go
+++ b/objects_test.go
@@ -831,13 +831,13 @@ func TestObjects(t *testing.T) {
 			out:    "create counter ip mytable test-counter { comment \"counter for unit tests\" ; }",
 		},
 		{
-			name:   "invalid crete counter with packets without bytes",
+			name:   "invalid create counter with packets without bytes",
 			verb:   createVerb,
 			object: &Counter{Name: "test-counter", Packets: PtrTo[uint64](100)},
 			err:    "cannot specify Packets without Bytes in create operation",
 		},
 		{
-			name:   "invalid crete counter with bytes without packets",
+			name:   "invalid create counter with bytes without packets",
 			verb:   createVerb,
 			object: &Counter{Name: "test-counter", Bytes: PtrTo[uint64](1500)},
 			err:    "cannot specify Bytes without Packets in create operation",

--- a/objects_test.go
+++ b/objects_test.go
@@ -92,6 +92,12 @@ func TestObjects(t *testing.T) {
 			out:    `delete table ip handle 5`,
 		},
 		{
+			name:   "destroy table",
+			verb:   destroyVerb,
+			object: &Table{},
+			out:    `destroy table ip mytable`,
+		},
+		{
 			name:   "invalid insert table",
 			verb:   insertVerb,
 			object: &Table{},
@@ -193,6 +199,14 @@ func TestObjects(t *testing.T) {
 				Handle: PtrTo(5),
 			},
 			out: `delete flowtable ip mytable handle 5`,
+		},
+		{
+			name: "destroy flowtable",
+			verb: destroyVerb,
+			object: &Flowtable{
+				Name: "myflowtable",
+			},
+			out: `destroy flowtable ip mytable myflowtable`,
 		},
 		{
 			name: "invalid insert flowtable",
@@ -297,6 +311,12 @@ func TestObjects(t *testing.T) {
 			verb:   deleteVerb,
 			object: &Chain{Handle: PtrTo(5)},
 			out:    `delete chain ip mytable handle 5`,
+		},
+		{
+			name:   "destroy chain",
+			verb:   destroyVerb,
+			object: &Chain{Name: "mychain"},
+			out:    `destroy chain ip mytable mychain`,
 		},
 		{
 			name:   "invalid insert chain",
@@ -433,6 +453,12 @@ func TestObjects(t *testing.T) {
 			out:    `delete rule ip mytable mychain handle 2`,
 		},
 		{
+			name:   "destroy rule",
+			verb:   destroyVerb,
+			object: &Rule{Chain: "mychain", Rule: "drop", Handle: PtrTo(2)},
+			out:    `destroy rule ip mytable mychain handle 2`,
+		},
+		{
 			name:   "invalid create rule",
 			verb:   createVerb,
 			object: &Rule{Chain: "mychain", Rule: "drop"},
@@ -547,6 +573,12 @@ func TestObjects(t *testing.T) {
 			out:    `delete set ip mytable handle 5`,
 		},
 		{
+			name:   "destroy set",
+			verb:   destroyVerb,
+			object: &Set{Name: "myset", Type: "ipv4_addr"},
+			out:    `destroy set ip mytable myset`,
+		},
+		{
 			name:   "invalid insert set",
 			verb:   insertVerb,
 			object: &Set{Name: "myset", Type: "ipv4_addr"},
@@ -654,6 +686,12 @@ func TestObjects(t *testing.T) {
 			out:    `delete map ip mytable handle 5`,
 		},
 		{
+			name:   "destroy map",
+			verb:   destroyVerb,
+			object: &Map{Name: "mymap", Type: "ipv4_addr : ipv4_addr"},
+			out:    `destroy map ip mytable mymap`,
+		},
+		{
 			name:   "invalid insert map",
 			verb:   insertVerb,
 			object: &Map{Name: "mymap", Type: "ipv4_addr : ipv4_addr"},
@@ -740,6 +778,18 @@ func TestObjects(t *testing.T) {
 			out:    `delete element ip mytable mymap { 10.0.0.1 }`,
 		},
 		{
+			name:   "destroy (set) element",
+			verb:   destroyVerb,
+			object: &Element{Set: "myset", Key: []string{"10.0.0.1"}},
+			out:    `destroy element ip mytable myset { 10.0.0.1 }`,
+		},
+		{
+			name:   "destroy (map) element",
+			verb:   destroyVerb,
+			object: &Element{Map: "mymap", Key: []string{"10.0.0.1"}, Value: []string{"192.168.1.1"}},
+			out:    `destroy element ip mytable mymap { 10.0.0.1 }`,
+		},
+		{
 			name:   "invalid add element with no Set",
 			verb:   addVerb,
 			object: &Element{Key: []string{"10.0.0.1"}},
@@ -762,6 +812,12 @@ func TestObjects(t *testing.T) {
 			verb:   addVerb,
 			object: &Element{Set: "myset"},
 			err:    "no key",
+		},
+		{
+			name:   "invalid add map element with no Value",
+			verb:   addVerb,
+			object: &Element{Map: "mymap", Key: []string{"10.0.0.1"}},
+			err:    "no map value",
 		},
 		{
 			name:   "invalid add element with Value but no Key",
@@ -793,6 +849,7 @@ func TestObjects(t *testing.T) {
 			object: &Element{Set: "myset", Key: []string{"10.0.0.1"}},
 			err:    "not implemented",
 		},
+
 		// Counters
 		{
 			name:   "add counter with comment",
@@ -861,6 +918,12 @@ func TestObjects(t *testing.T) {
 			out:    "delete counter ip mytable handle 5",
 		},
 		{
+			name:   "destroy counter by name",
+			verb:   destroyVerb,
+			object: &Counter{Name: "test-counter"},
+			out:    "destroy counter ip mytable test-counter",
+		},
+		{
 			name:   "invalid insert counter",
 			verb:   insertVerb,
 			object: &Counter{Name: "test-counter"},
@@ -921,8 +984,8 @@ func TestObjects(t *testing.T) {
 		})
 	}
 
-	// add, create, flush, insert, replace, delete, reset
-	numVerbs := 7
+	// add, create, flush, insert, replace, reset, delete, destroy
+	numVerbs := 8
 	for objType, verbs := range tested {
 		if len(verbs) != numVerbs {
 			t.Errorf("expected to test %d verbs for %s, got %d (%v)", numVerbs, objType, len(verbs), verbs)

--- a/transaction.go
+++ b/transaction.go
@@ -44,6 +44,7 @@ const (
 	insertVerb  verb = "insert"
 	replaceVerb verb = "replace"
 	deleteVerb  verb = "delete"
+	destroyVerb verb = "destroy"
 	flushVerb   verb = "flush"
 	resetVerb   verb = "reset"
 )
@@ -125,10 +126,10 @@ func (tx *Transaction) Flush(obj Object) {
 	tx.operation(flushVerb, obj)
 }
 
-// Delete adds an "nft delete" operation to tx, deleting obj. The Delete() call always
-// succeeds, but if obj does not exist or cannot be deleted based on the information
-// provided (eg, Handle is required but not set) then an error will be returned when the
-// transaction is Run.
+// Delete adds an "nft delete" operation to tx, deleting obj, which must exist. The
+// Delete() call always succeeds, but if obj does not exist or cannot be deleted based on
+// the information provided (eg, Handle is required but not set) then an error will be
+// returned when the transaction is Run.
 func (tx *Transaction) Delete(obj Object) {
 	tx.operation(deleteVerb, obj)
 }
@@ -138,4 +139,50 @@ func (tx *Transaction) Delete(obj Object) {
 // returned when the transaction is Run.
 func (tx *Transaction) Reset(obj Object) {
 	tx.operation(resetVerb, obj)
+}
+
+// Destroy adds an "nft destroy" operation to tx, ensuring that obj does not exist, by
+// deleting it if it does exist. The Destroy() call always succeeds, but if obj cannot be
+// deleted based on the information provided (eg, Handle is required but not set) then an
+// error will be returned when the transaction is Run.
+//
+// Support for the actual "nft destroy" command requires kernel 6.3+ and nft 1.0.7+. You
+// can create the Interface with the `RequireDestroy` option if you want construction to
+// fail on older hosts. Alternatively, you can create the interface with the
+// `EmulateDestroy` option, in which case knftables will emulate Destroy by doing an
+// Add+Delete. In that case, obj must be valid for both an Add and a Delete. (Even if the
+// system you are on supports destroy, you may only call Destroy() in a
+// backward-compatible way if you are using `EmulateDestroy`.) In particular, this means:
+//
+//   - You can only Destroy() objects by Name or Key, not by Handle.
+//   - You can't Destroy() a Rule (since they can only be deleted by Handle).
+//   - You do not need to include optional values in obj (e.g. base chain properties) but
+//     if you do include them, they need to be correct.
+//   - When Destroy()ing a Set or Map you must include the correct Type.
+//   - When Destroy()ing a Map Element you must include the correct Value.
+func (tx *Transaction) Destroy(obj Object) {
+	if tx.err != nil {
+		return
+	}
+	if tx.err = obj.validate(destroyVerb, tx.nftContext); tx.err != nil {
+		return
+	}
+
+	if tx.emulateDestroy {
+		err := obj.validate(addVerb, tx.nftContext)
+		if err == nil {
+			err = obj.validate(deleteVerb, tx.nftContext)
+		}
+		if err != nil {
+			tx.err = fmt.Errorf("object is not compatible with EmulateDestroy: %w", err)
+			return
+		}
+	}
+
+	if tx.emulateDestroy && !tx.nftContext.hasDestroy {
+		tx.operations = append(tx.operations, operation{verb: addVerb, obj: obj})
+		tx.operations = append(tx.operations, operation{verb: deleteVerb, obj: obj})
+	} else {
+		tx.operations = append(tx.operations, operation{verb: destroyVerb, obj: obj})
+	}
 }

--- a/transaction.go
+++ b/transaction.go
@@ -49,25 +49,17 @@ const (
 )
 
 // populateCommandBuf populates the transaction as series of nft commands to the given bytes.Buffer.
-func (tx *Transaction) populateCommandBuf(buf *bytes.Buffer) error {
-	if tx.err != nil {
-		return tx.err
-	}
-
+func (tx *Transaction) populateCommandBuf(buf *bytes.Buffer) {
 	for _, op := range tx.operations {
 		op.obj.writeOperation(op.verb, tx.nftContext, buf)
 	}
-	return nil
 }
 
 // String returns the transaction as a string containing the nft commands; if there is
 // a pending error, it will be output as a comment at the end of the transaction.
 func (tx *Transaction) String() string {
 	buf := &bytes.Buffer{}
-	for _, op := range tx.operations {
-		op.obj.writeOperation(op.verb, tx.nftContext, buf)
-	}
-
+	tx.populateCommandBuf(buf)
 	if tx.err != nil {
 		fmt.Fprintf(buf, "# ERROR: %v", tx.err)
 	}

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -1,0 +1,187 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package knftables
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// Test Destroy semantics, and in particular, that we get the same errors whether or not
+// we have `nft destroy` support.
+func TestDestroy(t *testing.T) {
+	initialState := `
+		add table ip mytable
+		add chain ip mytable mychain
+		add chain ip mytable mybasechain { type nat hook postrouting priority 100 ; }
+		add set ip mytable myset { type ipv4_addr ; }
+		add map ip mytable mymap { type ipv4_addr : ipv4_addr ; }
+		add element ip mytable myset { 10.0.0.1 }
+		add element ip mytable mymap { 10.0.0.1 : 192.168.1.1 }
+	`
+
+	for _, tc := range []struct {
+		name         string
+		object       Object
+		destroyOut   string
+		noDestroyOut string
+		err          string
+	}{
+		{
+			name:         "destroy table",
+			object:       &Table{},
+			destroyOut:   "destroy table ip mytable",
+			noDestroyOut: "add table ip mytable\ndelete table ip mytable",
+		},
+		{
+			name:         "destroy chain",
+			object:       &Chain{Name: "mychain"},
+			destroyOut:   "destroy chain ip mytable mychain",
+			noDestroyOut: "add chain ip mytable mychain\ndelete chain ip mytable mychain",
+		},
+		{
+			name:   "invalid destroy chain by Handle",
+			object: &Chain{Handle: PtrTo(5)},
+			err:    "no name specified",
+		},
+		{
+			name:         "destroy base chain",
+			object:       &Chain{Name: "mybasechain", Type: PtrTo(NATType), Hook: PtrTo(PostroutingHook), Priority: PtrTo(SNATPriority)},
+			destroyOut:   "destroy chain ip mytable mybasechain",
+			noDestroyOut: "add chain ip mytable mybasechain { type nat hook postrouting priority 100 ; }\ndelete chain ip mytable mybasechain",
+		},
+		{
+			name:   "invalid destroy base chain with invalid Add data",
+			object: &Chain{Name: "mybasechain", Hook: PtrTo(PostroutingHook)},
+			err:    "must specify Type and Priority",
+		},
+		{
+			name:         "destroy set",
+			object:       &Set{Name: "myset", Type: "ipv4_addr"},
+			destroyOut:   "destroy set ip mytable myset",
+			noDestroyOut: "add set ip mytable myset { type ipv4_addr ; }\ndelete set ip mytable myset",
+		},
+		{
+			name:   "invalid destroy set by handle",
+			object: &Set{Handle: PtrTo(5)},
+			err:    "no name specified for set",
+		},
+		{
+			name:   "invalid destroy set with no Type",
+			object: &Set{Name: "myset"},
+			err:    "must specify either Type or TypeOf",
+		},
+		{
+			name:         "destroy map",
+			object:       &Map{Name: "mymap", Type: "ipv4_addr : ipv4_addr"},
+			destroyOut:   "destroy map ip mytable mymap",
+			noDestroyOut: "add map ip mytable mymap { type ipv4_addr : ipv4_addr ; }\ndelete map ip mytable mymap",
+		},
+		{
+			name:   "invalid destroy map by handle",
+			object: &Map{Handle: PtrTo(5)},
+			err:    "no name specified for map",
+		},
+		{
+			name:   "invalid destroy map with no Type",
+			object: &Map{Name: "mymap"},
+			err:    "must specify either Type or TypeOf",
+		},
+		{
+			name:         "destroy set element",
+			object:       &Element{Set: "myset", Key: []string{"10.0.0.1"}},
+			destroyOut:   "destroy element ip mytable myset { 10.0.0.1 }",
+			noDestroyOut: "add element ip mytable myset { 10.0.0.1 }\ndelete element ip mytable myset { 10.0.0.1 }",
+		},
+		{
+			name:         "destroy map element",
+			object:       &Element{Map: "mymap", Key: []string{"10.0.0.1"}, Value: []string{"192.168.1.1"}},
+			destroyOut:   "destroy element ip mytable mymap { 10.0.0.1 }",
+			noDestroyOut: "add element ip mytable mymap { 10.0.0.1 : 192.168.1.1 }\ndelete element ip mytable mymap { 10.0.0.1 }",
+		},
+		{
+			name:   "invalid destroy map element with no Value",
+			object: &Element{Map: "mymap", Key: []string{"10.0.0.1"}},
+			err:    "no map value specified",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := NewFake(IPv4Family, "mytable")
+			fake.emulateDestroy = true
+			fake.hasDestroy = true
+			err := fake.ParseDump(initialState)
+			if err != nil {
+				t.Fatalf("unexpected error parsing initial state: %v", err)
+			}
+
+			tx := fake.NewTransaction()
+			tx.Destroy(tc.object)
+			err = fake.Run(context.Background(), tx)
+			if tc.err != "" {
+				if err == nil {
+					t.Errorf("with destroy, expected error containing %q, got none", tc.err)
+				} else if !strings.Contains(err.Error(), tc.err) {
+					t.Errorf("with destroy, expected error containing %q, got %v", tc.err, err)
+				}
+			} else if err != nil {
+				t.Errorf("with destroy, expected no error, got %v", err)
+			} else {
+				out := strings.TrimSuffix(tx.String(), "\n")
+				if out != tc.destroyOut {
+					t.Errorf("with destroy, expected commands %q, got %q", tc.destroyOut, out)
+				}
+			}
+			destroyDump := fake.Dump()
+
+			fake = NewFake(IPv4Family, "mytable")
+			fake.emulateDestroy = true
+			fake.hasDestroy = false
+			err = fake.ParseDump(initialState)
+			if err != nil {
+				t.Fatalf("unexpected error parsing initial state: %v", err)
+			}
+
+			tx = fake.NewTransaction()
+			tx.Destroy(tc.object)
+			err = fake.Run(context.Background(), tx)
+			if tc.err != "" {
+				if err == nil {
+					t.Errorf("emulating destroy, expected error containing %q, got none", tc.err)
+				} else if !strings.Contains(err.Error(), tc.err) {
+					t.Errorf("emulating destroy, expected error containing %q, got %v", tc.err, err)
+				}
+			} else if err != nil {
+				t.Errorf("emulating destroy, expected no error, got %v", err)
+			} else {
+				out := strings.TrimSuffix(tx.String(), "\n")
+				if out != tc.noDestroyOut {
+					t.Errorf("emulating destroy, expected commands %q, got %q", tc.noDestroyOut, out)
+				}
+			}
+			noDestroyDump := fake.Dump()
+
+			if tc.err == "" {
+				if diff := cmp.Diff(destroyDump, noDestroyDump); diff != "" {
+					t.Errorf("unexpected difference between final state with destroy and final state without destroy:\n%s", diff)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds `tx.Destroy()`, along with support for either requiring `nft destroy` to be available, or else for limiting the API so as to make it emulate-able.