### PR TITLE
[replaced] Fix List() to query specific table instead of filtering post-hoc

### DIFF
--- a/nftables.go
+++ b/nftables.go
@@ -367,16 +367,26 @@ func getJSONObjects(listOutput, objectType string) ([]map[string]interface{}, er
 func (nft *realNFTables) List(ctx context.Context, objectType string) ([]string, error) {
 	// All currently-existing nftables object types have plural forms that are just
 	// the singular form plus 's'.
-	var typeSingular, typePlural string
+	var typeSingular string
 	if objectType[len(objectType)-1] == 's' {
 		typeSingular = objectType[:len(objectType)-1]
-		typePlural = objectType
 	} else {
 		typeSingular = objectType
-		typePlural = objectType + "s"
 	}
 
-	cmd := exec.CommandContext(ctx, nft.path, "--json", "list", typePlural, string(nft.family))
+	var cmd *exec.Cmd
+	if nft.table != "" {
+		// List objects only from the specified table by using "list table" command.
+		// This is consistent with ListRules() and ListElements() which also scope
+		// their queries to a specific table, and avoids returning objects from
+		// unrelated tables that may exist in the same nftables family.
+		cmd = exec.CommandContext(ctx, nft.path, "--json", "list", "table", string(nft.family), nft.table)
+	} else {
+		// When no specific table is set, list all objects of the given type across all tables.
+		// This handles the case where the Interface was created without a specific table.
+		cmd = exec.CommandContext(ctx, nft.path, "--json", "list", typeSingular+"s", string(nft.family))
+	}
+
 	out, err := nft.exec.Run(cmd)
 	if err != nil {
 		return nil, fmt.Errorf("failed to run nft: %w", err)
@@ -389,11 +399,8 @@ func (nft *realNFTables) List(ctx context.Context, objectType string) ([]string,
 
 	var result []string
 	for _, obj := range objects {
-		objTable, _ := jsonVal[string](obj, "table")
-		if objTable != nft.table {
-			continue
-		}
-
+		// When querying a specific table, no filtering needed as "list table" only returns
+		// objects from that table. When table is empty, we return all objects across all tables.
 		if name, ok := jsonVal[string](obj, "name"); ok {
 			result = append(result, name)
 		}

--- a/nftables_test.go
+++ b/nftables_test.go
@@ -116,7 +116,7 @@ func TestListBad(t *testing.T) {
 
 			fexec.expected = append(fexec.expected,
 				expectedCmd{
-					args:   []string{"/nft", "--json", "list", "chains", "ip6"},
+					args:   []string{"/nft", "--json", "list", "table", "ip6", "testing"},
 					stdout: tc.nftOutput,
 					err:    nftErr,
 				},
@@ -148,13 +148,13 @@ func TestList(t *testing.T) {
 		{
 			name:       "singular objType",
 			objType:    "chain",
-			nftOutput:  `{"nftables": [{"metainfo": {"version": "1.0.1", "release_name": "Fearless Fosdick #3", "json_schema_version": 1}}, {"chain": {"family": "ip", "table": "testing", "name": "prerouting", "handle": 1, "type": "nat", "hook": "prerouting", "prio": -100, "policy": "accept"}}, {"chain": {"family": "ip", "table": "testing", "name": "output", "handle": 3, "type": "nat", "hook": "output", "prio": 0, "policy": "accept"}}, {"chain": {"family": "ip", "table": "testing", "name": "postrouting", "handle": 7, "type": "nat", "hook": "postrouting", "prio": 100, "policy": "accept"}}, {"chain": {"family": "ip", "table": "testing", "name": "KUBE-SERVICES", "handle": 11}}, {"chain": {"family": "ip", "table": "filter", "name": "INPUT", "handle": 1, "type": "filter", "hook": "input", "prio": 0, "policy": "accept"}}, {"chain": {"family": "ip", "table": "filter", "name": "FOO", "handle": 3}}]}`,
+			nftOutput:  `{"nftables": [{"metainfo": {"version": "1.0.1", "release_name": "Fearless Fosdick #3", "json_schema_version": 1}}, {"chain": {"family": "ip", "table": "testing", "name": "prerouting", "handle": 1, "type": "nat", "hook": "prerouting", "prio": -100, "policy": "accept"}}, {"chain": {"family": "ip", "table": "testing", "name": "output", "handle": 3, "type": "nat", "hook": "output", "prio": 0, "policy": "accept"}}, {"chain": {"family": "ip", "table": "testing", "name": "postrouting", "handle": 7, "type": "nat", "hook": "postrouting", "prio": 100, "policy": "accept"}}, {"chain": {"family": "ip", "table": "testing", "name": "KUBE-SERVICES", "handle": 11}}]}`,
 			listOutput: []string{"prerouting", "output", "postrouting", "KUBE-SERVICES"},
 		},
 		{
 			name:       "plural objType",
 			objType:    "chains",
-			nftOutput:  `{"nftables": [{"metainfo": {"version": "1.0.1", "release_name": "Fearless Fosdick #3", "json_schema_version": 1}}, {"chain": {"family": "ip", "table": "testing", "name": "prerouting", "handle": 1, "type": "nat", "hook": "prerouting", "prio": -100, "policy": "accept"}}, {"chain": {"family": "ip", "table": "testing", "name": "output", "handle": 3, "type": "nat", "hook": "output", "prio": 0, "policy": "accept"}}, {"chain": {"family": "ip", "table": "testing", "name": "postrouting", "handle": 7, "type": "nat", "hook": "postrouting", "prio": 100, "policy": "accept"}}, {"chain": {"family": "ip", "table": "testing", "name": "KUBE-SERVICES", "handle": 11}}, {"chain": {"family": "ip", "table": "filter", "name": "INPUT", "handle": 1, "type": "filter", "hook": "input", "prio": 0, "policy": "accept"}}, {"chain": {"family": "ip", "table": "filter", "name": "FOO", "handle": 3}}]}`,
+			nftOutput:  `{"nftables": [{"metainfo": {"version": "1.0.1", "release_name": "Fearless Fosdick #3", "json_schema_version": 1}}, {"chain": {"family": "ip", "table": "testing", "name": "prerouting", "handle": 1, "type": "nat", "hook": "prerouting", "prio": -100, "policy": "accept"}}, {"chain": {"family": "ip", "table": "testing", "name": "output", "handle": 3, "type": "nat", "hook": "output", "prio": 0, "policy": "accept"}}, {"chain": {"family": "ip", "table": "testing", "name": "postrouting", "handle": 7, "type": "nat", "hook": "postrouting", "prio": 100, "policy": "accept"}}, {"chain": {"family": "ip", "table": "testing", "name": "KUBE-SERVICES", "handle": 11}}]}`,
 			listOutput: []string{"prerouting", "output", "postrouting", "KUBE-SERVICES"},
 		},
 	} {
@@ -163,7 +163,7 @@ func TestList(t *testing.T) {
 
 			fexec.expected = append(fexec.expected,
 				expectedCmd{
-					args:   []string{"/nft", "--json", "list", "chains", "ip"},
+					args:   []string{"/nft", "--json", "list", "table", "ip", "testing"},
 					stdout: tc.nftOutput,
 				},
 			)


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it:

The `List()` method was using `nft list <objectType> <family>` which returns objects from ALL tables in the family, then filtering by table in post-processing. This caused issues when other nftables tables exist in the same family during tests.

This PR changes `List()` to use `nft list table <family> <table>` (consistent with `ListRules()` and `ListElements()`) when a specific table is set, which queries only that table, eliminating the need for post-processing table filtering.

When no specific table is set (`nft.table == ""`), the method falls back to the original behavior of listing all objects across all tables, maintaining backward compatibility with the multi-table use case.

## Which issue(s) this PR fixes:

Fixes issues in Kubernetes proxy tests when multiple nftables tables exist in the same family.

## Special notes for your reviewer:

This change makes `List()` behavior consistent with `ListRules()` and `ListElements()` when querying a specific table, while maintaining compatibility when the Interface has no associated table.

Key changes:
- When `nft.table != ""`: uses `nft list table <family> <table>` to query only the specific table
- When `nft.table == ""`: uses `nft list <objectType> <family>` to maintain multi-table compatibility
- Test data was updated to reflect that `nft list table` only returns objects from the specified table

## Does this PR introduce a user-facing change?

```release-note
Fixed List() method in knftables to query only the specified table instead of filtering all tables post-hoc, while maintaining backward compatibility for multi-table use cases
```