### PR TITLE
Fix List(), add ListAll()

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,26 +62,31 @@ families, you have two options: you can either create separate
 will need to explicitly fill in the `Family` and `Table` fields of
 every `Chain`, `Rule`, etc, object you create.)
 
-You can use the `List`, `ListRules`, and `ListElements` methods on the
-`Interface` to check if objects exist. `List` returns the names of
-`"chains"`, `"sets"`, or `"maps"` in the table, while `ListElements`
-returns `Element` objects and `ListRules` returns *partial* `Rule`
-objects.
+You can use the various `List*` methods on the `Interface` to check if
+objects exist. `ListAll` returns a map of the names of top-level
+objects in the table, sorted by object type, while `List` returns just
+the names of objects of a single type. `ListElements`, `ListRules`,
+and `ListCounters` returned parsed objects of the given types. Note
+that `ListRules` returns *partial* `Rule` objects; it does not fill in
+the `Rule` field.
 
 ```golang
-chains, err := nft.List(ctx, "chains")
+allChains, err := nft.List(ctx, "chains")
 if err != nil {
         return fmt.Errorf("could not list chains: %v", err)
 }
+for chain := range sets.New(allChains...).Difference(expectedChains) {
+        tx.Delete(&knftables.Chain{Name: chain})
+}
 
-FIXME
+// ...
 
 elements, err := nft.ListElements(ctx, "map", "mymap")
 if err != nil {
         return fmt.Errorf("could not list map elements: %v", err)
 }
 
-FIXME
+...
 ```
 
 To make changes, create a `Transaction`, add the appropriate

--- a/fake.go
+++ b/fake.go
@@ -126,6 +126,35 @@ func NewFake(family Family, table string) *Fake {
 
 var _ Interface = &Fake{}
 
+// ListAll is part of Interface.
+func (fake *Fake) ListAll(_ context.Context) (map[string][]string, error) {
+	fake.RLock()
+	defer fake.RUnlock()
+	if fake.Table == nil {
+		return nil, notFoundError("no such table %q", fake.table)
+	}
+
+	result := make(map[string][]string)
+
+	for name := range fake.Table.Flowtables {
+		result["flowtable"] = append(result["flowtable"], name)
+	}
+	for name := range fake.Table.Chains {
+		result["chain"] = append(result["chain"], name)
+	}
+	for name := range fake.Table.Sets {
+		result["set"] = append(result["set"], name)
+	}
+	for name := range fake.Table.Maps {
+		result["map"] = append(result["map"], name)
+	}
+	for name := range fake.Table.Counters {
+		result["counter"] = append(result["counter"], name)
+	}
+
+	return result, nil
+}
+
 // List is part of Interface.
 func (fake *Fake) List(_ context.Context, objectType string) ([]string, error) {
 	fake.RLock()

--- a/fake_test.go
+++ b/fake_test.go
@@ -227,6 +227,31 @@ func TestFakeRun(t *testing.T) {
 		t.Errorf("unexpected result from List(chains): %v", chains)
 	}
 
+	objs, err := fake.ListAll(context.Background())
+	if err != nil {
+		t.Errorf("unexpected error listing all: %v", err)
+	}
+	chains = objs["chain"]
+	sort.Strings(chains)
+	if !reflect.DeepEqual(chains, expectedChains) {
+		t.Errorf("unexpected result from ListAll(chain): %v", chains)
+	}
+	maps := objs["map"]
+	if len(maps) != 1 || maps[0] != "map1" {
+		t.Errorf("unexpected result from ListAll(map): %v", maps)
+	}
+	flowtables := objs["flowtable"]
+	if len(flowtables) != 1 || flowtables[0] != "myflowtable" {
+		t.Errorf("unexpected result from ListAll(flowtable): %v", flowtables)
+	}
+	counters := objs["counter"]
+	if len(counters) != 1 || counters[0] != "test-counter" {
+		t.Errorf("unexpected result from ListAll(counter): %v", counters)
+	}
+	if len(objs) != 4 {
+		t.Errorf("unexpected result from ListAll(): expected %d types, got %d: %v", 4, len(objs), objs)
+	}
+
 	tx = fake.NewTransaction()
 	tx.Delete(ruleToDelete)
 	tx.Reset(&Counter{Name: "test-counter"})

--- a/nftables.go
+++ b/nftables.go
@@ -40,6 +40,11 @@ type Interface interface {
 	// result.
 	Check(ctx context.Context, tx *Transaction) error
 
+	// ListAll returns a map containing the names of all objects in the table,
+	// grouped by object type. If there are no objects, this will return an empty list
+	// and no error.
+	ListAll(ctx context.Context) (map[string][]string, error)
+
 	// List returns a list of the names of the objects of objectType ("chain", "set",
 	// "map" or "counter") in the table. If there are no such objects, this will
 	// return an empty list and no error.
@@ -374,6 +379,37 @@ func getJSONObjects(listOutput, objectType string) ([]map[string]interface{}, er
 		}
 	}
 	return objects, nil
+}
+
+// ListAll is part of Interface.
+func (nft *realNFTables) ListAll(ctx context.Context) (map[string][]string, error) {
+	cmd := exec.CommandContext(ctx, nft.path, "--json", "list", "table", string(nft.family), nft.table)
+	out, err := nft.exec.Run(cmd)
+	if err != nil {
+		return nil, fmt.Errorf("failed to run nft: %w", err)
+	}
+
+	nftablesResult, err := parseJSONObjects(out)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string][]string)
+	for i, objContainer := range nftablesResult {
+		if i == 0 {
+			// Skip "metainfo"
+			continue
+		}
+		for objectType, obj := range objContainer {
+			if name, ok := jsonVal[string](obj, "name"); ok {
+				result[objectType] = append(result[objectType], name)
+			}
+			// Shouldn't be more than one field in objContainer, but ignore it
+			// if there is.
+			break
+		}
+	}
+	return result, nil
 }
 
 // List is part of Interface.

--- a/nftables_test.go
+++ b/nftables_test.go
@@ -178,6 +178,47 @@ func TestList(t *testing.T) {
 	}
 }
 
+func TestListAll(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		nftOutput  string
+		listOutput map[string][]string
+	}{
+		{
+			name:       "empty",
+			nftOutput:  `{"nftables": [{"metainfo": {"version": "1.0.1", "release_name": "Fearless Fosdick #3", "json_schema_version": 1}}]}`,
+			listOutput: map[string][]string{},
+		},
+		{
+			name:      "non-empty",
+			nftOutput: `{"nftables": [{"metainfo": {"version": "1.0.1", "release_name": "Fearless Fosdick #3", "json_schema_version": 1}}, {"chain": {"family": "ip", "table": "testing", "name": "prerouting", "handle": 1, "type": "nat", "hook": "prerouting", "prio": -100, "policy": "accept"}}, {"chain": {"family": "ip", "table": "testing", "name": "output", "handle": 3, "type": "nat", "hook": "output", "prio": 0, "policy": "accept"}}, {"chain": {"family": "ip", "table": "testing", "name": "postrouting", "handle": 7, "type": "nat", "hook": "postrouting", "prio": 100, "policy": "accept"}}, {"chain": {"family": "ip", "table": "testing", "name": "KUBE-SERVICES", "handle": 11}}, {"rule": {"family": "ip", "table": "testing", "chain": "testchain", "handle": 171, "expr": [{"match": {"op": "==", "left": {"meta": {"key": "iifname"}}, "right": "lo"}}, {"accept": null}]}}, {"set": {"family": "ip", "name": "test", "table": "testing", "type": "inet_proto", "handle": 16, "elem": []}}, {"counter": {"family": "ip", "name": "test-counter", "table": "testing", "handle": 1, "comment": "test-counter-comment", "packets": 100, "bytes": 5000}}]}`,
+			listOutput: map[string][]string{
+				"chain":   {"prerouting", "output", "postrouting", "KUBE-SERVICES"},
+				"set":     {"test"},
+				"counter": {"test-counter"},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			nft, fexec, _ := newTestInterface(t, IPv4Family, "testing")
+
+			fexec.expected = append(fexec.expected,
+				expectedCmd{
+					args:   []string{"/nft", "--json", "list", "table", "ip", "testing"},
+					stdout: tc.nftOutput,
+				},
+			)
+			result, err := nft.ListAll(context.Background())
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(result, tc.listOutput) {
+				t.Errorf("unexpected result: wanted %v got %v", tc.listOutput, result)
+			}
+		})
+	}
+}
+
 func TestRun(t *testing.T) {
 	nft, fexec, _ := newTestInterface(t, IPv4Family, "kube-proxy")
 


### PR DESCRIPTION
To work around `nft` parsing problems (https://github.com/kubernetes/kubernetes/issues/136786), we need to be careful to never make `nft` look at other people's tables. But this ends up making `List()` less efficient, so add a `ListAll()` method as well so kube-proxy can list multiple types at once.