### PR TITLE
Ensure google/nftables is only referenced on Linux

### DIFF
--- a/netlink_linux.go
+++ b/netlink_linux.go
@@ -1,0 +1,182 @@
+//go:build linux
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package knftables
+
+import (
+	"context"
+	"fmt"
+
+	gnftables "github.com/google/nftables"
+)
+
+var nftableFamilies = map[Family]gnftables.TableFamily{
+	IPv4Family:   gnftables.TableFamilyIPv4,
+	IPv6Family:   gnftables.TableFamilyIPv6,
+	InetFamily:   gnftables.TableFamilyINet,
+	ARPFamily:    gnftables.TableFamilyARP,
+	BridgeFamily: gnftables.TableFamilyBridge,
+	NetDevFamily: gnftables.TableFamilyNetdev,
+}
+
+type netlinkAdapter struct {
+	conn   *gnftables.Conn
+	family gnftables.TableFamily
+	table  string
+}
+
+func newNetlinkAdapter(family Family, table string) (netlink, error) {
+	c, err := gnftables.New()
+	if err != nil {
+		return nil, err
+	}
+	gnfamily, ok := nftableFamilies[family]
+	if !ok {
+		return nil, fmt.Errorf("unsupported family: %s", family)
+	}
+	return &netlinkAdapter{
+		conn:   c,
+		family: gnfamily,
+		table:  table,
+	}, nil
+}
+
+// List implements netlink.List
+func (n *netlinkAdapter) List(_ context.Context, objectType string) ([]string, error) {
+	objectType = canonicalObjectType(objectType)
+
+	switch objectType {
+	case "chain":
+		return n.listChains()
+	case "set", "map":
+		return n.listSets(objectType)
+	case "counter":
+		return n.listCounters()
+	case "flowtable":
+		return n.listFlowtables()
+	default:
+		return nil, fmt.Errorf("unsupported object type for netlink listing: %s", objectType)
+	}
+}
+
+func (n *netlinkAdapter) listChains() ([]string, error) {
+	chains, err := n.conn.ListChainsOfTableFamily(n.family)
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(chains))
+	for _, c := range chains {
+		if c.Table.Name == n.table {
+			names = append(names, c.Name)
+		}
+	}
+	return names, nil
+}
+
+func (n *netlinkAdapter) listSets(objectType string) ([]string, error) {
+	// google/nftables uses GetSets
+	sets, err := n.conn.GetSets(&gnftables.Table{Name: n.table, Family: n.family})
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(sets))
+	for _, s := range sets {
+		if s.IsMap == (objectType == "map") {
+			names = append(names, s.Name)
+		}
+	}
+	return names, nil
+}
+
+func (n *netlinkAdapter) listCounters() ([]string, error) {
+	// nftables.Conn doesn't have explicit ListCounters high level method that returns counters
+	// It has GetObj looking for ObjTypeCounter.
+	objs, err := n.conn.GetObjects(&gnftables.Table{Name: n.table, Family: n.family})
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(objs))
+	for _, o := range objs {
+		if c, ok := o.(*gnftables.CounterObj); ok {
+			names = append(names, c.Name)
+		}
+	}
+	return names, nil
+}
+
+func (n *netlinkAdapter) listFlowtables() ([]string, error) {
+	flowtables, err := n.conn.ListFlowtables(&gnftables.Table{Name: n.table, Family: n.family})
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(flowtables))
+	for _, ft := range flowtables {
+		names = append(names, ft.Name)
+	}
+	return names, nil
+}
+
+// ListAll implements netlink.ListAll
+func (n *netlinkAdapter) ListAll(_ context.Context) (map[string][]string, error) {
+	result := make(map[string][]string)
+	if n.table != "" {
+		result["table"] = []string{n.table}
+	}
+
+	chains, err := n.listChains()
+	if err != nil {
+		return nil, err
+	}
+	if len(chains) > 0 {
+		result["chain"] = chains
+	}
+
+	sets, err := n.listSets("set")
+	if err != nil {
+		return nil, err
+	}
+	if len(sets) > 0 {
+		result["set"] = sets
+	}
+
+	maps, err := n.listSets("map")
+	if err != nil {
+		return nil, err
+	}
+	if len(maps) > 0 {
+		result["map"] = maps
+	}
+
+	counters, err := n.listCounters()
+	if err != nil {
+		return nil, err
+	}
+	if len(counters) > 0 {
+		result["counter"] = counters
+	}
+
+	flowtables, err := n.listFlowtables()
+	if err != nil {
+		return nil, err
+	}
+	if len(flowtables) > 0 {
+		result["flowtable"] = flowtables
+	}
+
+	return result, nil
+}

--- a/netlink_linux_test.go
+++ b/netlink_linux_test.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package knftables
 
 import (

--- a/netlink_nonlinux.go
+++ b/netlink_nonlinux.go
@@ -1,3 +1,5 @@
+//go:build !linux
+
 /*
 Copyright The Kubernetes Authors.
 
@@ -17,10 +19,9 @@ limitations under the License.
 package knftables
 
 import (
-	"context"
+	"errors"
 )
 
-type netlink interface {
-	List(ctx context.Context, objectType string) ([]string, error)
-	ListAll(ctx context.Context) (map[string][]string, error)
+func newNetlinkAdapter(_ Family, _ string) (netlink, error) {
+	return nil, errors.New("netlink is not supported on non-Linux platforms")
 }


### PR DESCRIPTION
netlink is only supported on Linux, and google/nftables fails to even build on non-Linux platforms. To allow knftables-dependent projects to build on other platforms, this isolates the google/nftables package so that it's only needed in Linux builds.