### PR TITLE
Add support for custom nft command executors

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -20,8 +20,10 @@ import (
 	"os/exec"
 )
 
-// execer is a mockable wrapper around os/exec.
-type execer interface {
+// Execer is an interface wrapping os/exec that allows customizing how nft commands
+// are executed. This can be used to wrap command execution with nsenter for namespace
+// switching, add logging, or provide other command execution customizations.
+type Execer interface {
 	// LookPath wraps exec.LookPath
 	LookPath(file string) (string, error)
 
@@ -30,15 +32,22 @@ type execer interface {
 	Run(cmd *exec.Cmd) (string, error)
 }
 
-// realExec implements execer by actually using os/exec
+// DefaultExecer returns an Execer that uses os/exec directly to execute commands.
+// This is the same Execer used by New(). It can be used as a base for custom
+// Execer implementations that need to wrap the default behavior.
+func DefaultExecer() Execer {
+	return realExec{}
+}
+
+// realExec implements Execer by actually using os/exec
 type realExec struct{}
 
-// LookPath is part of execer
+// LookPath is part of Execer
 func (realExec) LookPath(file string) (string, error) {
 	return exec.LookPath(file)
 }
 
-// Run is part of execer
+// Run is part of Execer
 func (realExec) Run(cmd *exec.Cmd) (string, error) {
 	out, err := cmd.Output()
 	if err != nil {

--- a/nftables.go
+++ b/nftables.go
@@ -116,7 +116,7 @@ type realNFTables struct {
 	bufferMutex sync.Mutex
 	buffer      *bytes.Buffer
 
-	exec execer
+	exec Execer
 	path string
 
 	nl netlink
@@ -133,7 +133,7 @@ func optionSet(options []Option, option Option) bool {
 
 // newInternal creates a new nftables.Interface for interacting with the given table; this
 // is split out from New() so it can be used from unit tests with a fakeExec.
-func newInternal(family Family, table string, execer execer, options ...Option) (Interface, error) {
+func newInternal(family Family, table string, execer Execer, options ...Option) (Interface, error) {
 	var err error
 
 	if (family == "") != (table == "") {
@@ -254,6 +254,15 @@ func newInternal(family Family, table string, execer execer, options ...Option) 
 //     using `nft list`.
 func New(family Family, table string, options ...Option) (Interface, error) {
 	return newInternal(family, table, realExec{}, options...)
+}
+
+// NewWithExecer creates a new nftables.Interface using the provided Execer for command
+// execution. This allows customizing how the nft binary is discovered and invoked -- for
+// example, to wrap commands with nsenter for executing in a different namespace context.
+//
+// See New() for details on the family, table, and options parameters.
+func NewWithExecer(family Family, table string, execer Execer, options ...Option) (Interface, error) {
+	return newInternal(family, table, execer, options...)
 }
 
 // NewTransaction is part of Interface

--- a/nftables_test.go
+++ b/nftables_test.go
@@ -19,6 +19,7 @@ package knftables
 import (
 	"context"
 	"fmt"
+	"os/exec"
 	"reflect"
 	"strings"
 	"testing"
@@ -910,5 +911,125 @@ func TestMultiTable(t *testing.T) {
 	err = nft.Run(context.Background(), tx)
 	if err == nil {
 		t.Errorf("expected an error trying to add an object with wrong Family/Table")
+	}
+}
+
+func TestNewWithExecer(t *testing.T) {
+	fexec := newFakeExec(t)
+	fexec.expected = append(fexec.expected,
+		expectedCmd{
+			args:   []string{"/nft", "--version"},
+			stdout: "nftables v1.0.7 (Old Doc Yak)\n",
+		},
+		expectedCmd{
+			args:  []string{"/nft", "--check", "-f", "-"},
+			stdin: "add table ip testing { comment \"test\" ; }\n",
+		},
+	)
+
+	nft, err := NewWithExecer(IPv4Family, "testing", fexec)
+	if err != nil {
+		t.Fatalf("unexpected error from NewWithExecer: %v", err)
+	}
+
+	tx := nft.NewTransaction()
+	tx.Add(&Chain{
+		Name: "chain1",
+	})
+
+	expected := "add chain ip testing chain1\n"
+	fexec.expected = append(fexec.expected,
+		expectedCmd{
+			args:  []string{"/nft", "-f", "-"},
+			stdin: expected,
+		},
+	)
+
+	if err := nft.Run(context.Background(), tx); err != nil {
+		t.Errorf("unexpected error from Run: %v", err)
+	}
+}
+
+func TestNewWithExecerCommandWrapping(t *testing.T) {
+	// wrappingExecer wraps commands by prepending a prefix to the binary path,
+	// simulating the kind of wrapping needed for nsenter.
+	type wrappingExecer struct {
+		inner  *fakeExec
+		prefix string
+	}
+
+	fexec := newFakeExec(t)
+	wrapper := &wrappingExecer{inner: fexec, prefix: "/wrapped"}
+
+	fexec.expected = append(fexec.expected,
+		expectedCmd{
+			args:   []string{"/wrapped/nft", "--version"},
+			stdout: "nftables v1.0.7 (Old Doc Yak)\n",
+		},
+		expectedCmd{
+			args:  []string{"/wrapped/nft", "--check", "-f", "-"},
+			stdin: "add table ip testing { comment \"test\" ; }\n",
+		},
+	)
+
+	// wrappingExecer.LookPath returns the inner result but prefixed
+	lookPath := func(file string) (string, error) {
+		path, err := fexec.LookPath(file)
+		if err != nil {
+			return "", err
+		}
+		return wrapper.prefix + path, nil
+	}
+
+	// wrappingExecer.Run delegates to inner
+	run := func(cmd *exec.Cmd) (string, error) {
+		return fexec.Run(cmd)
+	}
+
+	// Use a funcExecer to implement Execer via closures
+	fe := &funcExecer{lookPathFn: lookPath, runFn: run}
+	nft, err := NewWithExecer(IPv4Family, "testing", fe)
+	if err != nil {
+		t.Fatalf("unexpected error from NewWithExecer: %v", err)
+	}
+
+	tx := nft.NewTransaction()
+	tx.Add(&Chain{
+		Name: "mychain",
+	})
+
+	fexec.expected = append(fexec.expected,
+		expectedCmd{
+			args:  []string{"/wrapped/nft", "-f", "-"},
+			stdin: "add chain ip testing mychain\n",
+		},
+	)
+
+	if err := nft.Run(context.Background(), tx); err != nil {
+		t.Errorf("unexpected error from Run: %v", err)
+	}
+}
+
+// funcExecer is a test helper that implements Execer via function closures.
+type funcExecer struct {
+	lookPathFn func(string) (string, error)
+	runFn      func(*exec.Cmd) (string, error)
+}
+
+func (f *funcExecer) LookPath(file string) (string, error) {
+	return f.lookPathFn(file)
+}
+
+func (f *funcExecer) Run(cmd *exec.Cmd) (string, error) {
+	return f.runFn(cmd)
+}
+
+func TestDefaultExecer(t *testing.T) {
+	e := DefaultExecer()
+	if e == nil {
+		t.Fatal("DefaultExecer() returned nil")
+	}
+	if _, ok := e.(realExec); !ok {
+		t.Errorf("DefaultExecer() returned %T, expected realExec", e)
 	}
 }


### PR DESCRIPTION
Istio's CNI plugin programs nftables rules for sidecar traffic redirection using the knftables library. When a K8s pod runs with user namespaces (`hostUsers: false`), the CNI plugin applies the rules from the host's user namespace, while the pod's Envoy sidecar runs as UID 1337 in a different user namespace. As a result, `skuid` and `skgid` rules fail because the kernel sees different UIDs across the namespace boundary. To fix this, Istio needs to run every nft invocation in the pod's user and network namespaces, for example: `nsenter --user=<pod-user-ns> --net=<pod-net-ns> nft ...`.

Currently, knftables keeps its execer interface private and hardcodes `realExec{}` in the `New()` constructor. Consumers therefore cannot customize how nft commands are discovered or executed.

Exporting the interface and adding an alternate constructor would allow Istio and other consumers to use a custom executor that wraps commands with `nsenter`, adds logging, or performs other command-level transformations while continuing to use the knftables API to program nftables rules.

These changes are fully backward compatible, and existing consumers can continue using `New()` without any changes.